### PR TITLE
feat: implement Spherre constructor

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -8,6 +8,10 @@ edition = "2024_07"
 [dependencies]
 starknet = "2.8.5"
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.35.1" }
+assert_macros = ">=2.9.2"
+
+[tool.fmt]
+sort-module-level-items = true
 
 [[target.starknet-contract]]
 casm = true

--- a/src/account.cairo
+++ b/src/account.cairo
@@ -5,8 +5,8 @@ pub mod SpherreAccount {
         actions::{
             change_threshold_tx::ChangeThresholdTransaction,
             member_permission_tx::MemberPermissionTransaction, member_tx::MemberTransaction,
-            nft_tx::NFTTransaction, token_tx::TokenTransaction
-        }
+            nft_tx::NFTTransaction, token_tx::TokenTransaction,
+        },
     };
     use starknet::ContractAddress;
 
@@ -14,13 +14,13 @@ pub mod SpherreAccount {
     component!(
         path: ChangeThresholdTransaction,
         storage: change_threshold_transaction,
-        event: ChangeThresholdEvent
+        event: ChangeThresholdEvent,
     );
     component!(path: MemberTransaction, storage: member_transaction, event: MemberTransactionEvent);
     component!(
         path: MemberPermissionTransaction,
         storage: member_permission_transaction,
-        event: MemberPermissionTransactionEvent
+        event: MemberPermissionTransactionEvent,
     );
     component!(path: NFTTransaction, storage: nft_transaction, event: NFTTransactionEvent);
     component!(path: TokenTransaction, storage: token_transaction, event: TokenTransactionEvent);

--- a/src/account_data.cairo
+++ b/src/account_data.cairo
@@ -1,8 +1,8 @@
 #[starknet::component]
 pub mod AccountData {
-    use spherre::types::{TransactionType, TransactionStatus};
-    use starknet::{ContractAddress};
+    use spherre::types::{TransactionStatus, TransactionType};
     use starknet::storage::{Map};
+    use starknet::{ContractAddress};
     #[storage]
     pub struct Storage {
         transactions: Map<u256, Transaction>,
@@ -18,6 +18,6 @@ pub mod AccountData {
         tx_type: TransactionType,
         tx_status: TransactionStatus,
         date_created: u64,
-        date_executed: u64
+        date_executed: u64,
     }
 }

--- a/src/components/permission_control.cairo
+++ b/src/components/permission_control.cairo
@@ -1,10 +1,10 @@
 #[starknet::component]
 pub mod PermissionControl {
-    use starknet::{ContractAddress};
     use starknet::storage::{Map};
+    use starknet::{ContractAddress};
     #[storage]
     pub struct Storage {
-        member_permission: Map<(felt252, ContractAddress), bool>
+        member_permission: Map<(felt252, ContractAddress), bool>,
     }
 
     #[event]
@@ -14,12 +14,12 @@ pub mod PermissionControl {
     #[derive(Drop, starknet::Event)]
     pub struct PermissionGranted {
         pub permission: felt252,
-        pub member: ContractAddress
+        pub member: ContractAddress,
     }
 
     #[derive(Drop, starknet::Event)]
     pub struct PermissionRevoked {
         pub permission: felt252,
-        pub account: ContractAddress
+        pub account: ContractAddress,
     }
 }

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,8 +1,8 @@
-pub mod spherre;
 pub mod account;
 pub mod account_data;
-pub mod types;
 pub mod errors;
+pub mod spherre;
+pub mod types;
 pub mod interfaces {
     pub mod iaccount;
     pub mod iaccount_data;
@@ -25,4 +25,9 @@ pub mod actions {
     pub mod member_tx;
     pub mod nft_tx;
     pub mod token_tx;
+}
+
+#[cfg(test)]
+pub mod tests {
+    pub mod test_spherre;
 }

--- a/src/spherre.cairo
+++ b/src/spherre.cairo
@@ -1,9 +1,48 @@
 #[starknet::contract]
 pub mod Spherre {
-    use starknet::ContractAddress;
+    use core::starknet::{
+        storage::{StorableStoragePointerReadAccess, StoragePointerWriteAccess},
+        {ContractAddress, contract_address_const},
+    };
 
     #[storage]
     struct Storage {
         owner: ContractAddress,
+        name: ByteArray,
+        description: ByteArray,
+    }
+
+    pub mod Errors {
+        pub const ERR_DEPLOYER_ZERO: felt252 = 'Deployer should not be zero';
+        pub const ERR_OWNER_ZERO: felt252 = 'Owner should not be zero';
+        pub const ERR_INVALID_MEMBER_THRESHOLD: felt252 = 'Members must meet threshold';
+    }
+
+    #[constructor]
+    pub fn constructor(
+        ref self: ContractState,
+        deployer: ContractAddress,
+        owner: ContractAddress,
+        name: ByteArray,
+        description: ByteArray,
+        members: Array<ContractAddress>,
+        threshold: u64,
+    ) {
+        assert(deployer != contract_address_const::<0>(), Errors::ERR_DEPLOYER_ZERO);
+        assert(owner != contract_address_const::<0>(), Errors::ERR_OWNER_ZERO);
+        assert((members.len()).into() >= threshold, Errors::ERR_INVALID_MEMBER_THRESHOLD);
+        self.name.write(name);
+        self.description.write(description);
+    }
+
+    #[generate_trait]
+    pub impl SpherreImpl of ISpherreImpl {
+        fn get_name(self: @ContractState) -> ByteArray {
+            self.name.read()
+        }
+
+        fn get_description(self: @ContractState) -> ByteArray {
+            self.description.read()
+        }
     }
 }

--- a/src/tests/test_spherre.cairo
+++ b/src/tests/test_spherre.cairo
@@ -1,1 +1,104 @@
+use crate::spherre::{Spherre, Spherre::ISpherreImpl};
+use starknet::contract_address_const;
 
+
+// setting up the contract state
+fn CONTRACT_STATE() -> Spherre::ContractState {
+    Spherre::contract_state_for_testing()
+}
+
+// Validate Deployer Address
+// This test ensures that the deployer address is not set to zero.
+// If the deployer address is zero, contract deployment should fail.
+#[test]
+#[should_panic(expected: 'Deployer should not be zero')]
+fn test_deployer_is_not_zero_address() {
+    let mut state = CONTRACT_STATE();
+    Spherre::constructor(
+        ref state,
+        contract_address_const::<0>(),
+        contract_address_const::<0>(),
+        "John Doe",
+        "John Does's Sphere",
+        array![],
+        4,
+    );
+}
+
+// Validate Owner Address
+// This test checks that the owner address is not zero.
+// The owner must have a valid address to manage the contract.
+#[test]
+#[should_panic(expected: 'Owner should not be zero')]
+fn test_owner_is_not_zero_address() {
+    let mut state = CONTRACT_STATE();
+    Spherre::constructor(
+        ref state,
+        contract_address_const::<2>(),
+        contract_address_const::<0>(),
+        "John Doe",
+        "John Does's Sphere",
+        array![],
+        4,
+    );
+}
+
+// Validate Member Threshold
+// This test verifies that the number of members is not less than the threshold.
+// The contract should require at least `threshold` members to function correctly.
+#[test]
+#[should_panic(expected: 'Members must meet threshold')]
+fn test_members_meet_threshold() {
+    let mut state = CONTRACT_STATE();
+    Spherre::constructor(
+        ref state,
+        contract_address_const::<2>(),
+        contract_address_const::<10>(),
+        "John Doe",
+        "John Does's Sphere",
+        array![contract_address_const::<4>(), contract_address_const::<5>()],
+        4,
+    );
+}
+
+// Validate Name Assignment
+// This test confirms that the contract name is correctly stored in `self.name`.
+// The provided name should match what was set during deployment.
+#[test]
+fn test_name_is_set_correctly() {
+    let mut state = CONTRACT_STATE();
+    let set_name: ByteArray = "John Doe";
+    let set_description: ByteArray = "John Does's Sphere";
+    Spherre::constructor(
+        ref state,
+        contract_address_const::<2>(),
+        contract_address_const::<10>(),
+        set_name,
+        set_description,
+        array![contract_address_const::<4>(), contract_address_const::<5>()],
+        2,
+    );
+    let actual_name: ByteArray = state.get_name();
+    assert_eq!(actual_name, "John Doe");
+}
+
+// Validate Description Assignment
+// This test ensures that the contract description is properly stored in `self.description`.
+// The description should be retrievable as expected.
+#[test]
+fn test_description_is_set_correctly() {
+    let mut state = CONTRACT_STATE();
+    let new_name: ByteArray = "John Doe";
+    let set_description: ByteArray = "John Does's Sphere";
+    Spherre::constructor(
+        ref state,
+        contract_address_const::<2>(),
+        contract_address_const::<10>(),
+        new_name,
+        set_description,
+        array![contract_address_const::<4>(), contract_address_const::<5>()],
+        2,
+    );
+    let actual_description: ByteArray = state.get_description();
+    assert_eq!(actual_description, "John Does's Sphere");
+}

--- a/src/types.cairo
+++ b/src/types.cairo
@@ -5,7 +5,7 @@ pub enum TransactionStatus {
     INITIATED,
     REJECTED,
     APPROVED,
-    EXECUTED
+    EXECUTED,
 }
 
 #[derive(Drop, Copy, starknet::Store)]
@@ -17,14 +17,14 @@ pub enum TransactionType {
     MEMBER_PERMISSION_EDIT,
     THRESHOLD_CHANGE,
     TOKEN_SEND,
-    NFT_SEND
+    NFT_SEND,
 }
 
 #[derive(Drop, Copy)]
 pub enum PermissionEnum {
     PROPOSER,
     VOTER,
-    EXECUTOR
+    EXECUTOR,
 }
 
 pub mod Permissions {


### PR DESCRIPTION
### Summary  
- Implemented the constructor for the Spherre contract to initialize key attributes.  
- Ensured validations for deployer, owner, and members threshold.  

### Changes  
- Added `constructor` function with required parameters.  
- Included necessary asserts to validate inputs.  

### How to Test  
- Deploy the contract and check initial state variables.  
- Run test cases to ensure correct behavior.  

### Before Testing
- Added `assert_macros = ">=2.9.2"` in `Scarb.toml` to use the necessary asserts and referred to the module in lib.cairo

### Related Issues  
Closes #8
