### PR TITLE
Feat: Test for permission control

### DIFF
--- a/src/components/permission_control.cairo
+++ b/src/components/permission_control.cairo
@@ -18,7 +18,7 @@ pub mod PermissionControl {
     /// Events emitted by this component.
     #[event]
     #[derive(Drop, starknet::Event)]
-    enum Event {
+    pub enum Event {
         PermissionGranted: PermissionGranted,
         PermissionRevoked: PermissionRevoked,
     }
@@ -59,9 +59,9 @@ pub mod PermissionControl {
     }
     /// Internal implementation.
     #[generate_trait]
-    impl PermissionControlInternalImpl<
+    pub impl InternalImpl<
         TContractState, +HasComponent<TContractState>
-    > of PermissionControlInternalTrait<TContractState> {
+    > of InternalTrait<TContractState> {
         /// Assigns the PROPOSER permission to a member.
         /// Emits a PermissionGranted event.
         /// @param member The address of the member (ContractAddress).
@@ -140,12 +140,12 @@ pub mod PermissionControl {
         /// Requirements:
         ///
         /// - The caller must have `role`'s admin role.
-        fn _revoke_proposer_permission(
-            ref self: ComponentState<TContractState>, permission: felt252, member: ContractAddress,
+        fn revoke_proposer_permission(
+            ref self: ComponentState<TContractState>, member: ContractAddress,
         ) {
             let permissioned = self.has_permission(member, Permissions::PROPOSER);
             if (permissioned) {
-                self.revoke_permission(member, permission);
+                self.revoke_permission(member, Permissions::PROPOSER);
             }
             Errors::MISSING_ROLE;
         }
@@ -157,12 +157,12 @@ pub mod PermissionControl {
         /// Requirements:
         ///
         /// - The caller must have `role`'s admin role.
-        fn _revoke_voter_permission(
-            ref self: ComponentState<TContractState>, permission: felt252, member: ContractAddress,
+        fn revoke_voter_permission(
+            ref self: ComponentState<TContractState>, member: ContractAddress,
         ) {
             let permissioned = self.has_permission(member, Permissions::VOTER);
             if (permissioned) {
-                self.revoke_permission(member, permission);
+                self.revoke_permission(member, Permissions::VOTER);
             }
             Errors::MISSING_ROLE;
         }
@@ -174,12 +174,12 @@ pub mod PermissionControl {
         /// Requirements:
         ///
         /// - The caller must have `role`'s admin role.
-        fn _revoke_executor_permission(
-            ref self: ComponentState<TContractState>, permission: felt252, member: ContractAddress,
+        fn revoke_executor_permission(
+            ref self: ComponentState<TContractState>, member: ContractAddress,
         ) {
             let permissioned = self.has_permission(member, Permissions::EXECUTOR);
             if (permissioned) {
-                self.revoke_permission(member, permission);
+                self.revoke_permission(member, Permissions::EXECUTOR);
             }
             Errors::MISSING_ROLE;
         }

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -32,4 +32,7 @@ pub mod actions {
 pub mod tests {
     pub mod test_account;
     pub mod test_account_data;
+    // pub mod test_component_changes;
+    pub mod test_permission_control;
+    pub mod utils;
 }

--- a/src/tests/test_permission_control.cairo
+++ b/src/tests/test_permission_control.cairo
@@ -1,0 +1,187 @@
+use MockPermissionContract::InternalTrait;
+use snforge_std::{declare, ContractClassTrait, DeclareResultTrait};
+use spherre::components::permission_control::PermissionControl;
+use spherre::interfaces::ipermission_control::{IPermissionControl, IPermissionControlDispatcher};
+
+use spherre::tests::utils::{MEMBER_ONE};
+use spherre::types::Permissions;
+#[starknet::contract]
+pub mod MockPermissionContract {
+    use spherre::components::permission_control::PermissionControl;
+    use starknet::ContractAddress;
+
+    component!(
+        path: PermissionControl, storage: permission_control_storage, event: PermissionControlEvent
+    );
+
+    #[abi(embed_v0)]
+    pub impl PermissionControlImpl =
+        PermissionControl::PermissionControl<ContractState>;
+
+    pub impl PermissionControlInternalImpl = PermissionControl::InternalImpl<ContractState>;
+
+    #[storage]
+    pub struct Storage {
+        #[substorage(v0)]
+        pub permission_control_storage: PermissionControl::Storage,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    pub enum Event {
+        #[flat]
+        PermissionControlEvent: PermissionControl::Event,
+    }
+
+
+    #[generate_trait]
+    pub impl InternalImpl of InternalTrait {
+        fn assign_proposer_permission(ref self: ContractState, member: ContractAddress) {
+            self.permission_control_storage.assign_proposer_permission(member);
+        }
+
+        fn assign_voter_permission(ref self: ContractState, member: ContractAddress) {
+            self.permission_control_storage.assign_voter_permission(member);
+        }
+        fn assign_executor_permission(ref self: ContractState, member: ContractAddress) {
+            self.permission_control_storage.assign_executor_permission(member);
+        }
+        fn revoke_proposer_permission(ref self: ContractState, member: ContractAddress) {
+            self.permission_control_storage.revoke_proposer_permission(member);
+        }
+
+        fn revoke_voter_permission(ref self: ContractState, member: ContractAddress) {
+            self.permission_control_storage.revoke_voter_permission(member);
+        }
+        fn revoke_executor_permission(ref self: ContractState, member: ContractAddress) {
+            self.permission_control_storage.revoke_executor_permission(member);
+        }
+    }
+}
+// use MockPermissionContract::{PermissionControlInternalImpl::InternalTrait};
+
+// deploy mock permission contract and return the
+fn deploy_contract() -> IPermissionControlDispatcher {
+    let contract = declare("MockPermissionContract").unwrap().contract_class();
+    let (contract_address, _) = contract.deploy(@array![]).unwrap();
+    let dispatcher = IPermissionControlDispatcher { contract_address };
+    dispatcher
+}
+
+fn get_contract_state() -> MockPermissionContract::ContractState {
+    MockPermissionContract::contract_state_for_testing()
+}
+
+fn get_component_state() -> PermissionControl::ComponentState<
+    MockPermissionContract::ContractState
+> {
+    PermissionControl::component_state_for_testing()
+}
+
+type TestingState = PermissionControl::ComponentState<MockPermissionContract::ContractState>;
+
+impl TestingStateDefault of Default<TestingState> {
+    fn default() -> TestingState {
+        PermissionControl::component_state_for_testing()
+    }
+}
+
+
+// Testcase for the assign_proposer_permission logic.
+// assign proposer permission to member and
+// check if member has proposer permission.
+#[test]
+fn test_assign_proposer_permission() {
+    let member = MEMBER_ONE();
+    let mut state = get_contract_state();
+    // assign the proposer permission
+    state.assign_proposer_permission(member);
+    // check whether member has proposer permission
+    let check = state.has_permission(member, Permissions::PROPOSER);
+    assert(check, 'no proposer permission');
+}
+
+// Testcase for the assign_voter_permission logic.
+// assign voter permission to member and
+// check if member has voter permission.
+#[test]
+fn test_assign_voter_permission() {
+    let member = MEMBER_ONE();
+    let mut state = get_contract_state();
+    // assign the voter permission
+    state.assign_voter_permission(member);
+    // check whether member has voter permission
+    let check = state.has_permission(member, Permissions::VOTER);
+    assert(check, 'no voter permission');
+}
+
+// Testcase for the assign_executor_permission logic.
+// assign executor permission to member and
+// check if member has executor permission.
+#[test]
+fn test_assign_executor_permission() {
+    let member = MEMBER_ONE();
+    let mut state = get_contract_state();
+    // assign the executor permission
+    state.assign_executor_permission(member);
+    // check whether member has executor permission
+    let check = state.has_permission(member, Permissions::EXECUTOR);
+    assert(check, 'no executor permission');
+}
+
+// Testcase for the revoke_proposer_permission logic.
+// revoke proposer permission to member and
+// check if member no longer has proposer permission.
+#[test]
+fn test_revoke_proposer_permission() {
+    let member = MEMBER_ONE();
+    let mut state = get_contract_state();
+    // assign the proposer permission
+    state.assign_proposer_permission(member);
+    // check whether member has proposer permission
+    let check = state.has_permission(member, Permissions::PROPOSER);
+    assert(check, 'no proposer permission');
+    // revoke the proposer permission
+    state.revoke_proposer_permission(member);
+    // check whether member no longer has proposer permission
+    let check = state.has_permission(member, Permissions::PROPOSER);
+    assert(!check, 'proposer permission exists');
+}
+
+// Testcase for the revoke_voter_permission logic.
+// revoke voter permission to member and
+// check if member no longer has voter permission.
+#[test]
+fn test_revoke_voter_permission() {
+    let member = MEMBER_ONE();
+    let mut state = get_contract_state();
+    // assign the voter permission
+    state.assign_voter_permission(member);
+    // check whether member has voter permission
+    let check = state.has_permission(member, Permissions::VOTER);
+    assert(check, 'no voter permission');
+    // revoke the voter permission
+    state.revoke_voter_permission(member);
+    // check whether member no longer has voter permission
+    let check = state.has_permission(member, Permissions::VOTER);
+    assert(!check, 'voter permission exists');
+}
+
+// Testcase for the revoke_executor_permission logic.
+// revoke executor permission to member and
+// check if member no longer has executor permission.
+#[test]
+fn test_revoke_executor_permission() {
+    let member = MEMBER_ONE();
+    let mut state = get_contract_state();
+    // assign the executor permission
+    state.assign_executor_permission(member);
+    // check whether member has executor permission
+    let check = state.has_permission(member, Permissions::EXECUTOR);
+    assert(check, 'no executor permission');
+    // revoke the executor permission
+    state.revoke_executor_permission(member);
+    // check whether member no longer has executor permission
+    let check = state.has_permission(member, Permissions::EXECUTOR);
+    assert(!check, 'executor permission exists');
+}

--- a/src/tests/utils.cairo
+++ b/src/tests/utils.cairo
@@ -1,0 +1,21 @@
+use starknet::ContractAddress;
+
+pub fn OWNER() -> ContractAddress {
+    'owner'.try_into().unwrap()
+}
+
+pub fn ADMIN() -> ContractAddress {
+    'admin'.try_into().unwrap()
+}
+
+
+pub fn TEST_USER() -> ContractAddress {
+    'test_user'.try_into().unwrap()
+}
+
+pub fn MEMBER_ONE() -> ContractAddress {
+    'member_one'.try_into().unwrap()
+}
+pub fn MEMBER_TWO() -> ContractAddress {
+    'member_two'.try_into().unwrap()
+}


### PR DESCRIPTION
## Description 📝
Write tests for permission control components.
Created test for the following logics:
- `assign_proposer_permission` - logic to add the proposer permission to a member
- `assign_voter_permission` - logic to add the voter permission to a member
- `assign_executor_permission` - logic to add the executor permission to a member
- `revoke_proposer_permission` - logic to remove the proposer permission from a member
- `revoke_voter_permission` - logic to remove the voter permission from a member
- `revoke_executor_permission` - logic to remove the executor permission from a member

Created MockPermissionContract to use for testing.
Used contract_state_for_testing instead of deploying the contract because i am testing private functions.
All test passes locally (Consider adding  more tests for members with mutliple permissions)
Did some clean up as well. renamed some functions and an impl block.

## Related Issues 🔗
Fixes #24 

## Changes Made 🚀
- [x] ✨ Feature Implementation 
- [ ] 🐛 Bug Fix 
- [ ] 📚 Documentation Update 
- [ ] 🔨 Refactoring 
- [ ] ❓ Others (Specify) 

## Screenshots/Screen-record (if applicable) 🖼
<!-- If the change includes UI updates, add screenshots or link to screen recording here. -->

## Checklist ✅
- [x] 🛠 I have tested these changes. 
- [x] 📖 I have updated the documentation (if applicable). 
- [x] 🎨 This PR follows the project's coding style. 
- [x] 🧪 I have added necessary tests (if applicable). 

## Additional Notes 🗒
<!-- Any other relevant details or concerns. -->