### PR TITLE
Implement an entrypoint to check if a contract address is a member

### DIFF
--- a/src/account_data.cairo
+++ b/src/account_data.cairo
@@ -140,6 +140,23 @@ pub mod AccountData {
                 date_executed,
             }
         }
+
+        /// Checks if a given address is a member of the account
+        fn is_member(self: @ComponentState<TContractState>, address: ContractAddress) -> bool {
+            let no_of_members = self.members_count.read();
+            let mut i = 0;
+            let mut found = false;
+
+            while i < no_of_members {
+                let current_member = self.members.entry(i).read();
+                if current_member == address {
+                    found = true; 
+                }
+                i += 1;
+            };
+
+            found
+        }
     }
 
     #[generate_trait]

--- a/src/account_data.cairo
+++ b/src/account_data.cairo
@@ -150,7 +150,7 @@ pub mod AccountData {
             while i < no_of_members {
                 let current_member = self.members.entry(i).read();
                 if current_member == address {
-                    found = true; 
+                    found = true;
                 }
                 i += 1;
             };

--- a/src/interfaces/iaccount_data.cairo
+++ b/src/interfaces/iaccount_data.cairo
@@ -8,4 +8,5 @@ pub trait IAccountData<TContractState> {
     fn get_members_count(self: @TContractState) -> u64;
     fn get_threshold(self: @TContractState) -> (u64, u64);
     fn get_transaction(self: @TContractState, transaction_id: u256) -> Transaction;
+    fn is_member(self: @TContractState, address: ContractAddress) -> bool;
 }

--- a/src/tests/test_account_data.cairo
+++ b/src/tests/test_account_data.cairo
@@ -201,3 +201,36 @@ fn test_get_nonexistent_transaction() {
     // Attempt to retrieve a non-existent transaction
     state.get_transaction(u256 { low: 999, high: 0 });
 }
+
+#[test]
+fn test_is_member() {
+    let new_member = new_member();
+    let another_new_member = another_new_member();
+    let non_member = contract_address_const::<'non_member'>();
+    let member = member();
+    let contract_address = deploy_mock_contract();
+
+    let mock_contract_dispatcher = IAccountDataDispatcher { contract_address };
+
+    // Act: add members
+    start_cheat_caller_address(contract_address, member);
+    mock_contract_dispatcher.add_member(new_member);
+    mock_contract_dispatcher.add_member(another_new_member);
+    stop_cheat_caller_address(contract_address);
+
+    assert!(
+        mock_contract_dispatcher.is_member(new_member) == true,
+        "New member should be recognized as a member"
+    );
+
+    assert!(
+        mock_contract_dispatcher.is_member(another_new_member) == true,
+        "Another new member should be recognized as a member"
+    );
+
+    assert!(
+        mock_contract_dispatcher.is_member(non_member) == false,
+        "Non-member should not be recognized as a member"
+    );
+}
+


### PR DESCRIPTION
## Description 📝
Implemented the is_member function to check if a given contract address is a member of the account. Added unit tests to verify functionality.

## Changes Made 🚀
- [✅ ] ✨ Feature Implementation 

## Screenshots/Screen-record (if applicable) 🖼
Scarb Build 
![image](https://github.com/user-attachments/assets/34e3622d-3588-4fa0-b7c6-5c1219bd8504)
Scarb fmt 
![image](https://github.com/user-attachments/assets/21b2645e-1da2-457a-9716-fd63a4906f1f)
Scarb test
![image](https://github.com/user-attachments/assets/54231d46-34a4-4b56-bfaf-591ed4600eda)


## Checklist ✅
- [✅ ] 🛠 I have tested these changes. 
- [✅ ] 🎨 This PR follows the project's coding style. 
