### PR TITLE
Refactor: Cleanup

### DIFF
--- a/src/account.cairo
+++ b/src/account.cairo
@@ -10,6 +10,7 @@ pub mod SpherreAccount {
             nft_tx::NFTTransaction, token_tx::TokenTransaction,
         },
         {errors::Errors}, types::AccountDetails,
+        interfaces::iaccount::IAccount,
     };
     use starknet::{
         {ContractAddress, contract_address_const},
@@ -108,9 +109,8 @@ pub mod SpherreAccount {
             };
         self.account_data.set_threshold(threshold);
     }
-
-    #[generate_trait]
-    pub impl SpherreAccountImpl of ISpherreAccount {
+    #[abi(embed_v0)]
+    pub impl AccountImpl of IAccount<ContractState> {
         fn get_name(self: @ContractState) -> ByteArray {
             self.name.read()
         }
@@ -118,9 +118,9 @@ pub mod SpherreAccount {
         fn get_description(self: @ContractState) -> ByteArray {
             self.description.read()
         }
-
         fn get_account_details(self: @ContractState) -> AccountDetails {
             AccountDetails { name: self.name.read(), description: self.description.read() }
         }
     }
+
 }

--- a/src/account.cairo
+++ b/src/account.cairo
@@ -9,8 +9,7 @@ pub mod SpherreAccount {
             member_permission_tx::MemberPermissionTransaction, member_tx::MemberTransaction,
             nft_tx::NFTTransaction, token_tx::TokenTransaction,
         },
-        {errors::Errors}, types::AccountDetails,
-        interfaces::iaccount::IAccount,
+        {errors::Errors}, types::AccountDetails, interfaces::iaccount::IAccount,
     };
     use starknet::{
         {ContractAddress, contract_address_const},
@@ -122,5 +121,4 @@ pub mod SpherreAccount {
             AccountDetails { name: self.name.read(), description: self.description.read() }
         }
     }
-
 }

--- a/src/account_data.cairo
+++ b/src/account_data.cairo
@@ -72,7 +72,7 @@ pub mod AccountData {
         fn get_members_count(self: @ComponentState<TContractState>) -> u64 {
             self.members_count.read()
         }
-        
+
         //This takes no arguments and returns a tuple in which the first member is a threshold and
         //the second is members_count of an account
         fn get_threshold(self: @ComponentState<TContractState>) -> (u64, u64) {

--- a/src/account_data.cairo
+++ b/src/account_data.cairo
@@ -1,6 +1,5 @@
 #[starknet::component]
 pub mod AccountData {
-    use alexandria_storage::list::{ListTrait, List};
     use core::num::traits::Zero;
     use core::starknet::storage::{
         Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess, Vec, VecTrait,

--- a/src/account_data.cairo
+++ b/src/account_data.cairo
@@ -73,10 +73,7 @@ pub mod AccountData {
         fn get_members_count(self: @ComponentState<TContractState>) -> u64 {
             self.members_count.read()
         }
-
-        fn add_member(ref self: ComponentState<TContractState>, address: ContractAddress) {
-            self._add_member(address);
-        }
+        
         //This takes no arguments and returns a tuple in which the first member is a threshold and
         //the second is members_count of an account
         fn get_threshold(self: @ComponentState<TContractState>) -> (u64, u64) {

--- a/src/interfaces/iaccount_data.cairo
+++ b/src/interfaces/iaccount_data.cairo
@@ -4,7 +4,6 @@ use spherre::types::{Transaction};
 #[starknet::interface]
 pub trait IAccountData<TContractState> {
     fn get_account_members(self: @TContractState) -> Array<ContractAddress>;
-    fn add_member(ref self: TContractState, address: ContractAddress);
     fn get_members_count(self: @TContractState) -> u64;
     fn get_threshold(self: @TContractState) -> (u64, u64);
     fn get_transaction(self: @TContractState, transaction_id: u256) -> Transaction;

--- a/src/tests/mocks/mock_account_data.cairo
+++ b/src/tests/mocks/mock_account_data.cairo
@@ -24,7 +24,6 @@ pub mod MockContract {
         AccountDataEvent: AccountData::Event,
     }
 
-    
 
     #[generate_trait]
     pub impl PrivateImpl of PrivateTrait {
@@ -35,7 +34,7 @@ pub mod MockContract {
             let members = self.account_data.get_account_members();
             members
         }
-    
+
         fn get_members_count(self: @ContractState) -> u64 {
             self.account_data.members_count.read()
         }

--- a/src/tests/mocks/mock_account_data.cairo
+++ b/src/tests/mocks/mock_account_data.cairo
@@ -24,17 +24,21 @@ pub mod MockContract {
         AccountDataEvent: AccountData::Event,
     }
 
-    fn get_members(self: @ContractState) -> Array<ContractAddress> {
-        let members = self.account_data.get_account_members();
-        members
-    }
-
-    fn get_members_count(self: @ContractState) -> u64 {
-        self.account_data.members_count.read()
-    }
+    
 
     #[generate_trait]
     pub impl PrivateImpl of PrivateTrait {
+        fn is_member(self: @ContractState, member: ContractAddress) -> bool {
+            self.account_data.is_member(member)
+        }
+        fn get_members(self: @ContractState) -> Array<ContractAddress> {
+            let members = self.account_data.get_account_members();
+            members
+        }
+    
+        fn get_members_count(self: @ContractState) -> u64 {
+            self.account_data.members_count.read()
+        }
         fn set_threshold(ref self: ContractState, val: u64) {
             self.account_data.set_threshold(val);
         }
@@ -48,6 +52,10 @@ pub mod MockContract {
         // Expose the main contract's get_transaction function
         fn get_transaction(self: @ContractState, transaction_id: u256) -> Transaction {
             self.account_data.get_transaction(transaction_id)
+        }
+
+        fn add_member(ref self: ContractState, member: ContractAddress) {
+            self.account_data._add_member(member);
         }
     }
 }

--- a/src/tests/test_account.cairo
+++ b/src/tests/test_account.cairo
@@ -1,4 +1,4 @@
-use crate::account::{SpherreAccount, SpherreAccount::SpherreAccountImpl};
+use crate::account::{SpherreAccount, SpherreAccount::AccountImpl};
 use crate::types::AccountDetails;
 use starknet::contract_address_const;
 

--- a/src/tests/test_account_data.cairo
+++ b/src/tests/test_account_data.cairo
@@ -193,19 +193,12 @@ fn test_is_member() {
     let mut state = get_mock_contract_state();
     state.add_member(new_member);
     state.add_member(another_new_member);
-    assert!(
-        state.is_member(new_member),
-        "New member should be recognized as a member"
-    );
+    assert!(state.is_member(new_member), "New member should be recognized as a member");
 
     assert!(
-        state.is_member(another_new_member),
-        "Another new member should be recognized as a member"
+        state.is_member(another_new_member), "Another new member should be recognized as a member"
     );
 
-    assert!(
-        !state.is_member(non_member),
-        "Non-member should not be recognized as a member"
-    );
+    assert!(!state.is_member(non_member), "Non-member should not be recognized as a member");
 }
 

--- a/src/tests/test_account_data.cairo
+++ b/src/tests/test_account_data.cairo
@@ -47,14 +47,8 @@ fn get_mock_contract_state() -> MockContract::ContractState {
 #[should_panic(expected: 'Zero Address Caller')]
 fn test_zero_address_caller_should_fail() {
     let zero_address = zero_address();
-    let member = member();
-    let contract_address = deploy_mock_contract();
-
-    let mock_contract_dispatcher = IAccountDataDispatcher { contract_address };
-    // let mock_contract_internal_dispatcher = IAccountDataDispatcherTrait { contract_address };
-    start_cheat_caller_address(contract_address, member);
-    mock_contract_dispatcher.add_member(zero_address);
-    stop_cheat_caller_address(contract_address);
+    let mut state = get_mock_contract_state();
+    state.add_member(zero_address);
 }
 
 // This indirectly tests get_members_count
@@ -62,15 +56,9 @@ fn test_zero_address_caller_should_fail() {
 #[test]
 fn test_add_member() {
     let new_member = new_member();
-    let member = member();
-    let contract_address = deploy_mock_contract();
-
-    let mock_contract_dispatcher = IAccountDataDispatcher { contract_address };
-    start_cheat_caller_address(contract_address, member);
-    mock_contract_dispatcher.add_member(new_member);
-    stop_cheat_caller_address(contract_address);
-
-    let count = mock_contract_dispatcher.get_members_count();
+    let mut state = get_mock_contract_state();
+    state.add_member(new_member);
+    let count = state.get_members_count();
     assert(count == 1, 'Member not added');
 }
 
@@ -79,19 +67,14 @@ fn test_get_members() {
     let new_member = new_member();
     let another_new_member = another_new_member();
     let third_member = third_member();
-    let member = member();
-    let contract_address = deploy_mock_contract();
+    let mut state = get_mock_contract_state();
+    state.add_member(new_member);
+    state.add_member(another_new_member);
+    state.add_member(third_member);
 
-    let mock_contract_dispatcher = IAccountDataDispatcher { contract_address };
-    start_cheat_caller_address(contract_address, member);
-    mock_contract_dispatcher.add_member(new_member);
-    mock_contract_dispatcher.add_member(another_new_member);
-    mock_contract_dispatcher.add_member(third_member);
-    stop_cheat_caller_address(contract_address);
-
-    let count = mock_contract_dispatcher.get_members_count();
+    let count = state.get_members_count();
     assert(count == 3, 'Members not added');
-    let members = mock_contract_dispatcher.get_account_members();
+    let members = state.get_members();
     let member_0 = *members.at(0);
     let member_1 = *members.at(1);
     let member_2 = *members.at(2);
@@ -207,29 +190,21 @@ fn test_is_member() {
     let new_member = new_member();
     let another_new_member = another_new_member();
     let non_member = contract_address_const::<'non_member'>();
-    let member = member();
-    let contract_address = deploy_mock_contract();
-
-    let mock_contract_dispatcher = IAccountDataDispatcher { contract_address };
-
-    // Act: add members
-    start_cheat_caller_address(contract_address, member);
-    mock_contract_dispatcher.add_member(new_member);
-    mock_contract_dispatcher.add_member(another_new_member);
-    stop_cheat_caller_address(contract_address);
-
+    let mut state = get_mock_contract_state();
+    state.add_member(new_member);
+    state.add_member(another_new_member);
     assert!(
-        mock_contract_dispatcher.is_member(new_member) == true,
+        state.is_member(new_member),
         "New member should be recognized as a member"
     );
 
     assert!(
-        mock_contract_dispatcher.is_member(another_new_member) == true,
+        state.is_member(another_new_member),
         "Another new member should be recognized as a member"
     );
 
     assert!(
-        mock_contract_dispatcher.is_member(non_member) == false,
+        !state.is_member(non_member),
         "Non-member should not be recognized as a member"
     );
 }


### PR DESCRIPTION
## Description 📝
Cleanup the codebase and tweak some functionalities.
This tweaked functionalities involves:
- Remove `add_member` function from being a public entrypoint
- Change all `SpherreAccount` contract functions to  publlic entrypoint functions

## Related Issues 🔗
<!-- Link to related issues (if applicable), e.g., Fixes #123. -->

## Changes Made 🚀
- [ ] ✨ Feature Implementation 
- [ ] 🐛 Bug Fix 
- [ ] 📚 Documentation Update 
- [x] 🔨 Refactoring 
- [ ] ❓ Others (Specify) 

## Screenshots/Screen-record (if applicable) 🖼
<!-- If the change includes UI updates, add screenshots or link to screen recording here. -->

## Checklist ✅
- [x] 🛠 I have tested these changes. 
- [x] 📖 I have updated the documentation (if applicable). 
- [x] 🎨 This PR follows the project's coding style. 
- [x] 🧪 I have added necessary tests (if applicable). 

## Additional Notes 🗒
<!-- Any other relevant details or concerns. -->