### PR TITLE
Implement functionality to retrieve number of voters, proposers and executors

### DIFF
--- a/src/account_data.cairo
+++ b/src/account_data.cairo
@@ -1,14 +1,13 @@
 #[starknet::component]
 pub mod AccountData {
-    
     use core::num::traits::Zero;
     use core::starknet::storage::{
         Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess, Vec, VecTrait,
     };
     use spherre::components::permission_control;
-    use spherre::interfaces::ipermission_control::IPermissionControl;
     use spherre::errors::Errors;
     use spherre::interfaces::iaccount_data::IAccountData;
+    use spherre::interfaces::ipermission_control::IPermissionControl;
     use spherre::types::{TransactionStatus, TransactionType, Transaction, Permissions};
     use starknet::ContractAddress;
 
@@ -54,7 +53,8 @@ pub mod AccountData {
 
     #[embeddable_as(AccountData)]
     pub impl AccountDataImpl<
-        TContractState, +HasComponent<TContractState>,
+        TContractState,
+        +HasComponent<TContractState>,
         +Drop<TContractState>,
         impl PermissionControl: permission_control::PermissionControl::HasComponent<TContractState>,
     > of IAccountData<ComponentState<TContractState>> {
@@ -162,36 +162,39 @@ pub mod AccountData {
             let permission_control_comp = get_dep_component!(self, PermissionControl);
             let mut counter: u64 = 0;
             let no_of_members = self.members_count.read();
-            for index in 0..no_of_members {
-                let member = self.members.entry(index).read();
-                if permission_control_comp.has_permission(member, Permissions::VOTER) {
-                    counter = counter + 1;
-                }
-            };
+            for index in 0
+                ..no_of_members {
+                    let member = self.members.entry(index).read();
+                    if permission_control_comp.has_permission(member, Permissions::VOTER) {
+                        counter = counter + 1;
+                    }
+                };
             counter
         }
         fn get_number_of_proposers(self: @ComponentState<TContractState>) -> u64 {
             let permission_control_comp = get_dep_component!(self, PermissionControl);
             let mut counter: u64 = 0;
             let no_of_members = self.members_count.read();
-            for index in 0..no_of_members {
-                let member = self.members.entry(index).read();
-                if permission_control_comp.has_permission(member, Permissions::PROPOSER) {
-                    counter = counter + 1;
-                }
-            };
+            for index in 0
+                ..no_of_members {
+                    let member = self.members.entry(index).read();
+                    if permission_control_comp.has_permission(member, Permissions::PROPOSER) {
+                        counter = counter + 1;
+                    }
+                };
             counter
         }
         fn get_number_of_executors(self: @ComponentState<TContractState>) -> u64 {
             let permission_control_comp = get_dep_component!(self, PermissionControl);
             let mut counter: u64 = 0;
             let no_of_members = self.members_count.read();
-            for index in 0..no_of_members{
-                let member = self.members.entry(index).read();
-                if permission_control_comp.has_permission(member, Permissions::EXECUTOR) {
-                    counter = counter + 1;
-                }
-            };
+            for index in 0
+                ..no_of_members {
+                    let member = self.members.entry(index).read();
+                    if permission_control_comp.has_permission(member, Permissions::EXECUTOR) {
+                        counter = counter + 1;
+                    }
+                };
             counter
         }
     }

--- a/src/account_data.cairo
+++ b/src/account_data.cairo
@@ -162,7 +162,7 @@ pub mod AccountData {
             let permission_control_comp = get_dep_component!(self, PermissionControl);
             let mut counter: u64 = 0;
             let no_of_members = self.members_count.read();
-            for index in 1..no_of_members + 1 {
+            for index in 0..no_of_members {
                 let member = self.members.entry(index).read();
                 if permission_control_comp.has_permission(member, Permissions::VOTER) {
                     counter = counter + 1;
@@ -174,7 +174,7 @@ pub mod AccountData {
             let permission_control_comp = get_dep_component!(self, PermissionControl);
             let mut counter: u64 = 0;
             let no_of_members = self.members_count.read();
-            for index in 1..no_of_members + 1 {
+            for index in 0..no_of_members {
                 let member = self.members.entry(index).read();
                 if permission_control_comp.has_permission(member, Permissions::PROPOSER) {
                     counter = counter + 1;
@@ -186,7 +186,7 @@ pub mod AccountData {
             let permission_control_comp = get_dep_component!(self, PermissionControl);
             let mut counter: u64 = 0;
             let no_of_members = self.members_count.read();
-            for index in 1..no_of_members + 1 {
+            for index in 0..no_of_members{
                 let member = self.members.entry(index).read();
                 if permission_control_comp.has_permission(member, Permissions::EXECUTOR) {
                     counter = counter + 1;

--- a/src/interfaces/iaccount_data.cairo
+++ b/src/interfaces/iaccount_data.cairo
@@ -8,4 +8,7 @@ pub trait IAccountData<TContractState> {
     fn get_threshold(self: @TContractState) -> (u64, u64);
     fn get_transaction(self: @TContractState, transaction_id: u256) -> Transaction;
     fn is_member(self: @TContractState, address: ContractAddress) -> bool;
+    fn get_number_of_voters(self: @TContractState) -> u64;
+    fn get_number_of_proposers(self: @TContractState) -> u64;
+    fn get_number_of_executors(self: @TContractState) -> u64;
 }

--- a/src/tests/mocks/mock_account_data.cairo
+++ b/src/tests/mocks/mock_account_data.cairo
@@ -1,8 +1,9 @@
 #[starknet::contract]
 pub mod MockContract {
-    use AccountData::InternalTrait;
+    
+    // use AccountData::InternalTrait;
     use spherre::account_data::AccountData;
-    use spherre::components::permission_control::PermissionControl;
+    use spherre::components::permission_control::{PermissionControl};
     use spherre::types::Transaction;
     use starknet::ContractAddress;
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess,};
@@ -66,6 +67,24 @@ pub mod MockContract {
 
         fn add_member(ref self: ContractState, member: ContractAddress) {
             self.account_data._add_member(member);
+        }
+        fn assign_voter_permission(ref self: ContractState, member: ContractAddress) {
+            self.permission_control.assign_voter_permission(member);
+        }
+        fn assign_proposer_permission(ref self: ContractState, member: ContractAddress) {
+            self.permission_control.assign_proposer_permission(member);
+        }
+        fn assign_executor_permission(ref self: ContractState, member: ContractAddress) {
+            self.permission_control.assign_executor_permission(member);
+        }
+        fn get_number_of_voters(self: @ContractState) -> u64{
+            self.account_data.get_number_of_voters()
+        }
+        fn get_number_of_proposers(self: @ContractState) -> u64{
+            self.account_data.get_number_of_proposers()
+        }
+        fn get_number_of_executors(self: @ContractState) -> u64{
+            self.account_data.get_number_of_executors()
         }
     }
 }

--- a/src/tests/mocks/mock_account_data.cairo
+++ b/src/tests/mocks/mock_account_data.cairo
@@ -1,6 +1,5 @@
 #[starknet::contract]
 pub mod MockContract {
-    
     // use AccountData::InternalTrait;
     use spherre::account_data::AccountData;
     use spherre::components::permission_control::{PermissionControl};
@@ -16,7 +15,8 @@ pub mod MockContract {
     pub impl AccountDataInternalImpl = AccountData::InternalImpl<ContractState>;
 
     #[abi(embed_v0)]
-    pub impl PermissionControlImpl = PermissionControl::PermissionControl<ContractState>;
+    pub impl PermissionControlImpl =
+        PermissionControl::PermissionControl<ContractState>;
     pub impl PermissionInternalImpl = PermissionControl::InternalImpl<ContractState>;
 
     #[storage]
@@ -77,13 +77,13 @@ pub mod MockContract {
         fn assign_executor_permission(ref self: ContractState, member: ContractAddress) {
             self.permission_control.assign_executor_permission(member);
         }
-        fn get_number_of_voters(self: @ContractState) -> u64{
+        fn get_number_of_voters(self: @ContractState) -> u64 {
             self.account_data.get_number_of_voters()
         }
-        fn get_number_of_proposers(self: @ContractState) -> u64{
+        fn get_number_of_proposers(self: @ContractState) -> u64 {
             self.account_data.get_number_of_proposers()
         }
-        fn get_number_of_executors(self: @ContractState) -> u64{
+        fn get_number_of_executors(self: @ContractState) -> u64 {
             self.account_data.get_number_of_executors()
         }
     }

--- a/src/tests/mocks/mock_account_data.cairo
+++ b/src/tests/mocks/mock_account_data.cairo
@@ -2,26 +2,37 @@
 pub mod MockContract {
     use AccountData::InternalTrait;
     use spherre::account_data::AccountData;
+    use spherre::components::permission_control::PermissionControl;
     use spherre::types::Transaction;
     use starknet::ContractAddress;
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess,};
 
     component!(path: AccountData, storage: account_data, event: AccountDataEvent);
+    component!(path: PermissionControl, storage: permission_control, event: PermissionControlEvent);
 
     #[abi(embed_v0)]
     pub impl AccountDataImpl = AccountData::AccountData<ContractState>;
     pub impl AccountDataInternalImpl = AccountData::InternalImpl<ContractState>;
 
+    #[abi(embed_v0)]
+    pub impl PermissionControlImpl = PermissionControl::PermissionControl<ContractState>;
+    pub impl PermissionInternalImpl = PermissionControl::InternalImpl<ContractState>;
+
     #[storage]
     pub struct Storage {
         #[substorage(v0)]
         pub account_data: AccountData::Storage,
+        #[substorage(v0)]
+        pub permission_control: PermissionControl::Storage,
     }
 
     #[event]
     #[derive(Drop, starknet::Event)]
     enum Event {
+        #[flat]
         AccountDataEvent: AccountData::Event,
+        #[flat]
+        PermissionControlEvent: PermissionControl::Event,
     }
 
 

--- a/src/tests/test_account_data.cairo
+++ b/src/tests/test_account_data.cairo
@@ -216,7 +216,7 @@ fn test_get_number_of_voters() {
 }
 
 #[test]
-fn test_get_number_of_proposer  () {
+fn test_get_number_of_proposer() {
     let mut state = get_mock_contract_state();
     let new_member = new_member();
     let another_new_member = another_new_member();
@@ -229,7 +229,7 @@ fn test_get_number_of_proposer  () {
 }
 
 #[test]
-fn test_get_number_of_executors () {
+fn test_get_number_of_executors() {
     let mut state = get_mock_contract_state();
     let new_member = new_member();
     let another_new_member = another_new_member();

--- a/src/tests/test_account_data.cairo
+++ b/src/tests/test_account_data.cairo
@@ -202,3 +202,41 @@ fn test_is_member() {
     assert!(!state.is_member(non_member), "Non-member should not be recognized as a member");
 }
 
+#[test]
+fn test_get_number_of_voters() {
+    let mut state = get_mock_contract_state();
+    let new_member = new_member();
+    let another_new_member = another_new_member();
+    state.add_member(new_member);
+    state.add_member(another_new_member);
+    assert(state.get_number_of_voters() == 0, 'voters count should be 0');
+    state.assign_voter_permission(new_member);
+    state.assign_voter_permission(another_new_member);
+    assert(state.get_number_of_voters() == 2, 'voters count should be 2');
+}
+
+#[test]
+fn test_get_number_of_proposer  () {
+    let mut state = get_mock_contract_state();
+    let new_member = new_member();
+    let another_new_member = another_new_member();
+    state.add_member(new_member);
+    state.add_member(another_new_member);
+    assert(state.get_number_of_proposers() == 0, 'voters count should be 0');
+    state.assign_proposer_permission(new_member);
+    state.assign_proposer_permission(another_new_member);
+    assert(state.get_number_of_proposers() == 2, 'voters count should be 2');
+}
+
+#[test]
+fn test_get_number_of_executors () {
+    let mut state = get_mock_contract_state();
+    let new_member = new_member();
+    let another_new_member = another_new_member();
+    state.add_member(new_member);
+    state.add_member(another_new_member);
+    assert(state.get_number_of_executors() == 0, 'voters count should be 0');
+    state.assign_executor_permission(new_member);
+    state.assign_executor_permission(another_new_member);
+    assert(state.get_number_of_executors() == 2, 'voters count should be 2');
+}


### PR DESCRIPTION
## Description 📝
This PR implements three new functions to get analytics data of the account: get_number_of_voters, get_number_of_proposers and get_number_of_executors. These functions provide a convenient way to retrieve data regarding permissions in the account.

## Implementation Details 🔨
- Added `get_number_of_proposers` function to get the number of members with the proposal permission in the account.
- Added `get_number_of_voters` function to get the number of members with the voter permission in the account.
- Added `get_number_of_executors` function to get the number of members with the executor permission in the account.
-  The functions loop through the member data and performs the checks appropriately
- Functions utilize dependency component of `PermissionControl`.

## Testing ❓
- Unit tests added to verify the functionality of the three functions
- Confirmed proper integration with existing permission model

## Related Issues 🔗
Fixes #29 

## Changes Made 🚀
- [x] ✨ Feature Implementation 
- [ ] 🐛 Bug Fix 
- [ ] 📚 Documentation Update 
- [ ] 🔨 Refactoring 
- [ ] ❓ Others (Specify) 

## Screenshots/Screen-record (if applicable) 🖼
<!-- If the change includes UI updates, add screenshots or link to screen recording here. -->

## Checklist ✅
- [x] 🛠 I have tested these changes. 
- [x] 📖 I have updated the documentation (if applicable). 
- [x] 🎨 This PR follows the project's coding style. 
- [x] 🧪 I have added necessary tests (if applicable). 

## Additional Notes 🗒
<!-- Any other relevant details or concerns. -->