### PR TITLE
feat: add create transaction functionality and tests

### DIFF
--- a/src/errors.cairo
+++ b/src/errors.cairo
@@ -8,6 +8,8 @@ pub mod Errors {
     pub const ThresholdError: felt252 = 'Threshold is too high, lower it';
     pub const NON_ZERO_THRESHOLD: felt252 = 'Threshold must be > 0';
     pub const ERR_NOT_OWNER: felt252 = 'Caller is not the owner';
+    pub const ERR_NOT_MEMBER: felt252 = 'Caller is not a member';
+    pub const ERR_NOT_PROPOSER: felt252 = 'Caller is not a proposer';
 
     // Constants for the Ownable error format
     pub const ERR_NOT_OWNER_SELECTOR: felt252 =

--- a/src/tests/mocks/mock_account_data.cairo
+++ b/src/tests/mocks/mock_account_data.cairo
@@ -1,9 +1,21 @@
+use spherre::types::{TransactionType, Transaction};
+use starknet::ContractAddress;
+
+#[starknet::interface]
+pub trait IMockContract<TContractState> {
+    fn create_transaction_pub(ref self: TContractState, tx_type: TransactionType) -> u256;
+    fn add_member_pub(ref self: TContractState, member: ContractAddress);
+    fn assign_proposer_permission_pub(ref self: TContractState, member: ContractAddress);
+    fn get_transaction_pub(ref self: TContractState, id: u256) -> Transaction;
+}
+
+
 #[starknet::contract]
 pub mod MockContract {
     // use AccountData::InternalTrait;
     use spherre::account_data::AccountData;
     use spherre::components::permission_control::{PermissionControl};
-    use spherre::types::Transaction;
+    use spherre::types::{Transaction, TransactionType};
     use starknet::ContractAddress;
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess,};
 
@@ -36,6 +48,21 @@ pub mod MockContract {
         PermissionControlEvent: PermissionControl::Event,
     }
 
+    #[abi(embed_v0)]
+    pub impl MockContractImpl of super::IMockContract<ContractState> {
+        fn create_transaction_pub(ref self: ContractState, tx_type: TransactionType) -> u256 {
+            self.account_data.create_transaction(tx_type)
+        }
+        fn add_member_pub(ref self: ContractState, member: ContractAddress) {
+            self.account_data._add_member(member);
+        }
+        fn assign_proposer_permission_pub(ref self: ContractState, member: ContractAddress) {
+            self.permission_control.assign_proposer_permission(member);
+        }
+        fn get_transaction_pub(ref self: ContractState, id: u256) -> Transaction {
+            self.account_data.get_transaction(id)
+        }
+    }
 
     #[generate_trait]
     pub impl PrivateImpl of PrivateTrait {


### PR DESCRIPTION
## Description 📝
This change implements the `create_transaction` private function in the AccountData component. This function is a core part of the transaction creation flow, generating unique transaction IDs and properly storing transaction data.

### Implementation Details
Added `create_transaction` function that:
- Validates the caller has member status
- Verifies the caller has proposer permission
- Generates a unique transaction ID
- Creates and stores the transaction with the specified type
- Records creation timestamp and proposer address
- Returns the transaction ID for further processing

### Security Features
- Permission verification through the PermissionControl component
- Member status validation before allowing transaction creation
- Proper error handling with descriptive error codes

### Technical Notes
- Transaction IDs are implemented as incrementing u256 values
- Transaction status is set to INITIATED by default
- Uses block timestamp for creation date tracking
- Maintains transaction count in storage for ID generation

### Testing
- Added tests for successful transaction creation with various types
- Verified permission validation works correctly
- Tested error cases for non-members and users without proposer permission


## Related Issues 🔗
Fixes #45 

## Changes Made 🚀
- [x] ✨ Feature Implementation 
- [ ] 🐛 Bug Fix 
- [ ] 📚 Documentation Update 
- [ ] 🔨 Refactoring 
- [ ] ❓ Others (Specify) 

## Screenshots/Screen-record (if applicable) 🖼
<!-- If the change includes UI updates, add screenshots or link to screen recording here. -->

## Checklist ✅
- [x] 🛠 I have tested these changes. 
- [x] 📖 I have updated the documentation (if applicable). 
- [x] 🎨 This PR follows the project's coding style. 
- [x] 🧪 I have added necessary tests (if applicable). 

## Additional Notes 🗒
<!-- Any other relevant details or concerns. -->