### PR TITLE
feat: add approve_transaction functionality and test

### DIFF
--- a/src/account_data.cairo
+++ b/src/account_data.cairo
@@ -9,6 +9,7 @@ pub mod AccountData {
     use spherre::interfaces::iaccount_data::IAccountData;
     use spherre::interfaces::ipermission_control::IPermissionControl;
     use spherre::types::{TransactionStatus, TransactionType, Transaction, Permissions};
+    use starknet::storage::MutableVecTrait;
     use starknet::{ContractAddress, get_caller_address, get_block_timestamp};
 
     #[storage]
@@ -39,6 +40,8 @@ pub mod AccountData {
     pub enum Event {
         AddedMember: AddedMember,
         ThresholdUpdated: ThresholdUpdated,
+        TransactionApproved: TransactionApproved,
+        TransactionVoted: TransactionVoted,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -50,6 +53,23 @@ pub mod AccountData {
     pub struct ThresholdUpdated {
         threshold: u64,
         date_updated: u64,
+    }
+
+
+    #[derive(Drop, starknet::Event)]
+    pub struct TransactionVoted {
+        #[key]
+        transaction_id: u256,
+        #[key]
+        voter: ContractAddress,
+        date_voted: u64
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct TransactionApproved {
+        #[key]
+        transaction_id: u256,
+        date_approved: u64
     }
 
     #[embeddable_as(AccountData)]
@@ -79,8 +99,8 @@ pub mod AccountData {
             self.members_count.read()
         }
 
-        //This takes no arguments and returns a tuple in which the first member is a threshold and
-        //the second is members_count of an account
+        //This takes no arguments and returns a tuple where the first member is the threshold and
+        //the second is the members_count of the account
         fn get_threshold(self: @ComponentState<TContractState>) -> (u64, u64) {
             let threshold: u64 = self.threshold.read();
             let members_count: u64 = self.members_count.read();
@@ -91,9 +111,7 @@ pub mod AccountData {
             self: @ComponentState<TContractState>, transaction_id: u256
         ) -> Transaction {
             // Check if transaction ID is within valid range
-            let tx_count = self.tx_count.read();
-            assert(transaction_id <= tx_count, 'Transaction ID out of range');
-            assert(transaction_id != 0, 'Transaction ID out of range');
+            self.assert_valid_transaction(transaction_id);
 
             // Access the storage entry for the given transaction ID
             let storage_path = self.transactions.entry(transaction_id);
@@ -255,6 +273,85 @@ pub mod AccountData {
             // update the transaction count
             self.tx_count.write(transaction_id);
             transaction_id
+        }
+        // Approve a transaction
+        // @params tx_id: The transaction id
+        // @params caller: The approver
+        fn approve_transaction(
+            ref self: ComponentState<TContractState>, tx_id: u256, caller: ContractAddress
+        ) {
+            // check if caller can vote
+            self.assert_caller_can_vote(tx_id, caller);
+
+            // update has_voted map to prevent double voting
+            self.has_voted.entry((tx_id, caller)).write(true);
+
+            // get the transaction
+            let transaction = self.transactions.entry(tx_id);
+            // add the caller to the list of approvers
+            transaction.approved.append().write(caller);
+
+            let approvers_length = transaction.approved.len();
+            let (threshold, _) = self.get_threshold();
+            let timestamp = get_block_timestamp();
+
+            // check if approval threshold has been reached and updated
+            // the transaction status if that is the case.
+            if approvers_length >= threshold {
+                transaction.tx_status.write(TransactionStatus::APPROVED);
+                self.emit(TransactionApproved { transaction_id: tx_id, date_approved: timestamp });
+            }
+            self
+                .emit(
+                    TransactionVoted { transaction_id: tx_id, voter: caller, date_voted: timestamp }
+                )
+        }
+
+        fn _update_transaction_status(
+            ref self: ComponentState<TContractState>,
+            transaction_id: u256,
+            status: TransactionStatus
+        ) {
+            self.assert_valid_transaction(transaction_id);
+            self.transactions.entry(transaction_id).tx_status.write(status);
+        }
+
+        fn assert_valid_transaction(self: @ComponentState<TContractState>, transaction_id: u256) {
+            let tx_count = self.tx_count.read();
+            assert(transaction_id <= tx_count, Errors::ERR_INVALID_TRANSACTION);
+            assert(transaction_id != 0, Errors::ERR_INVALID_TRANSACTION);
+        }
+        fn assert_is_votable_transaction(
+            self: @ComponentState<TContractState>, transaction_id: u256
+        ) {
+            self.assert_valid_transaction(transaction_id);
+            let transaction = self.transactions.entry(transaction_id);
+            assert(
+                transaction.tx_status.read() == TransactionStatus::INITIATED,
+                Errors::ERR_TRANSACTION_NOT_VOTABLE
+            );
+        }
+        fn assert_caller_can_vote(
+            self: @ComponentState<TContractState>, transaction_id: u256, caller: ContractAddress
+        ) {
+            // check for transaction validity
+            // check if transaction in range
+            self.assert_valid_transaction(transaction_id);
+            // check if transaction is votable
+            self.assert_is_votable_transaction(transaction_id);
+            // check if the caller is a member
+            assert(self.is_member(caller), Errors::ERR_NOT_MEMBER);
+            // check if the caller has the voter permission
+            let permission_control_comp = get_dep_component!(self, PermissionControl);
+            assert(
+                permission_control_comp.has_permission(caller, Permissions::VOTER),
+                Errors::ERR_NOT_VOTER
+            );
+            // check that member has not voted
+            assert(
+                !self.has_voted.entry((transaction_id, caller)).read(),
+                Errors::ERR_CALLER_CANNOT_VOTE
+            );
         }
     }
 }

--- a/src/errors.cairo
+++ b/src/errors.cairo
@@ -10,6 +10,10 @@ pub mod Errors {
     pub const ERR_NOT_OWNER: felt252 = 'Caller is not the owner';
     pub const ERR_NOT_MEMBER: felt252 = 'Caller is not a member';
     pub const ERR_NOT_PROPOSER: felt252 = 'Caller is not a proposer';
+    pub const ERR_NOT_VOTER: felt252 = 'Caller is not a voter';
+    pub const ERR_INVALID_TRANSACTION: felt252 = 'Transaction is out of range';
+    pub const ERR_TRANSACTION_NOT_VOTABLE: felt252 = 'Transaction is not votable';
+    pub const ERR_CALLER_CANNOT_VOTE: felt252 = 'Caller cannot vote again';
 
     // Constants for the Ownable error format
     pub const ERR_NOT_OWNER_SELECTOR: felt252 =

--- a/src/tests/mocks/mock_account_data.cairo
+++ b/src/tests/mocks/mock_account_data.cairo
@@ -1,12 +1,16 @@
-use spherre::types::{TransactionType, Transaction};
+use spherre::types::{TransactionType, Transaction, TransactionStatus};
 use starknet::ContractAddress;
 
 #[starknet::interface]
 pub trait IMockContract<TContractState> {
     fn create_transaction_pub(ref self: TContractState, tx_type: TransactionType) -> u256;
+    fn approve_transaction_pub(ref self: TContractState, tx_id: u256, caller: ContractAddress);
+    fn update_transaction_status(ref self: TContractState, tx_id: u256, status: TransactionStatus);
     fn add_member_pub(ref self: TContractState, member: ContractAddress);
     fn assign_proposer_permission_pub(ref self: TContractState, member: ContractAddress);
+    fn assign_voter_permission_pub(ref self: TContractState, member: ContractAddress);
     fn get_transaction_pub(ref self: TContractState, id: u256) -> Transaction;
+    fn set_threshold_pub(ref self: TContractState, val: u64);
 }
 
 
@@ -15,7 +19,7 @@ pub mod MockContract {
     // use AccountData::InternalTrait;
     use spherre::account_data::AccountData;
     use spherre::components::permission_control::{PermissionControl};
-    use spherre::types::{Transaction, TransactionType};
+    use spherre::types::{Transaction, TransactionType, TransactionStatus};
     use starknet::ContractAddress;
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess,};
 
@@ -53,14 +57,29 @@ pub mod MockContract {
         fn create_transaction_pub(ref self: ContractState, tx_type: TransactionType) -> u256 {
             self.account_data.create_transaction(tx_type)
         }
+        fn approve_transaction_pub(ref self: ContractState, tx_id: u256, caller: ContractAddress) {
+            self.account_data.approve_transaction(tx_id, caller)
+        }
+        fn update_transaction_status(
+            ref self: ContractState, tx_id: u256, status: TransactionStatus
+        ) {
+            self.account_data._update_transaction_status(tx_id, status)
+        }
         fn add_member_pub(ref self: ContractState, member: ContractAddress) {
             self.account_data._add_member(member);
         }
         fn assign_proposer_permission_pub(ref self: ContractState, member: ContractAddress) {
             self.permission_control.assign_proposer_permission(member);
         }
+        fn assign_voter_permission_pub(ref self: ContractState, member: ContractAddress) {
+            self.permission_control.assign_voter_permission(member);
+        }
         fn get_transaction_pub(ref self: ContractState, id: u256) -> Transaction {
             self.account_data.get_transaction(id)
+        }
+
+        fn set_threshold_pub(ref self: ContractState, val: u64) {
+            self.account_data.set_threshold(val);
         }
     }
 

--- a/src/tests/test_account_data.cairo
+++ b/src/tests/test_account_data.cairo
@@ -298,7 +298,6 @@ fn test_approve_transaction_successful() {
     let mock_contract = deploy_mock_contract();
     let caller = member();
 
-    
     // Add Member
     start_cheat_caller_address(mock_contract.contract_address, caller);
     mock_contract.add_member_pub(caller);
@@ -312,17 +311,13 @@ fn test_approve_transaction_successful() {
     // Create Transaction
     let tx_id = mock_contract.create_transaction_pub(TransactionType::TOKEN_SEND);
 
-
     // Approve Transaction (Should Pass)
     mock_contract.approve_transaction_pub(tx_id, caller);
     stop_cheat_caller_address(mock_contract.contract_address);
 
-
-
     let transaction = mock_contract.get_transaction_pub(tx_id);
     assert(transaction.approved.len() == 1, 'Approvers count should be 1');
     assert(transaction.tx_status == TransactionStatus::APPROVED, 'Transaction should be approved');
-
 }
 
 


### PR DESCRIPTION
## Description 📝
This change implements the approve_transaction function in the AccountData component. This function is a core part of the transaction approval flow, adding the caller to the list of approvers of the transaction.

### Implementation Details
Added `approve_transaction` function that:
- Assert that the transaction exists
- Validates the caller has member status
- Verifies the caller has voter permission
- Verified that the caller has not voted
- Adds the caller to the approved list
- Check if the number of approvers have reached the threshold
- Update the transaction status to APPROVED if threshold reached
- Emit TransactionVoted event
- Emit TransactionApproved event if transaction status is changed to APPROVED

## Related Issues 🔗
Fixes #47 

## Changes Made 🚀
- [x] ✨ Feature Implementation 
- [ ] 🐛 Bug Fix 
- [ ] 📚 Documentation Update 
- [ ] 🔨 Refactoring 
- [ ] ❓ Others (Specify) 

## Screenshots/Screen-record (if applicable) 🖼
<!-- If the change includes UI updates, add screenshots or link to screen recording here. -->

## Checklist ✅
- [x] 🛠 I have tested these changes. 
- [x] 📖 I have updated the documentation (if applicable). 
- [x] 🎨 This PR follows the project's coding style. 
- [x] 🧪 I have added necessary tests (if applicable). 

## Additional Notes 🗒
<!-- Any other relevant details or concerns. -->