### PR TITLE
Feat: Implemented reject_transaction Function in AccountData Component

### DIFF
--- a/src/account_data.cairo
+++ b/src/account_data.cairo
@@ -331,15 +331,19 @@ pub mod AccountData {
             transaction.rejected.append().write(caller);
 
             let rejectors_length = transaction.rejected.len();
+            let approved_length = transaction.approved.len();
+            let no_of_possible_voters = self.get_number_of_voters();
+            let members_that_have_voted = approved_length + rejectors_length;
+            let not_voted_yet = no_of_possible_voters - members_that_have_voted;
+            let max_possible_approved_length = approved_length + not_voted_yet;
             let (threshold, _) = self.get_threshold();
             let timestamp = get_block_timestamp();
-
             // check if approval threshold has been reached and update
             // the transaction status if that is the case.
             // According to issue description, transaction is automatically
             // rejected in any other case
 
-            if rejectors_length >= threshold {
+            if max_possible_approved_length < threshold {
                 transaction.tx_status.write(TransactionStatus::REJECTED);
                 self.emit(TransactionRejected { transaction_id: tx_id, date_approved: timestamp });
             }

--- a/src/account_data.cairo
+++ b/src/account_data.cairo
@@ -335,23 +335,19 @@ pub mod AccountData {
             let timestamp = get_block_timestamp();
 
             // check if approval threshold has been reached and update
-            // the transaction status if that is the case. 
+            // the transaction status if that is the case.
             // According to issue description, transaction is automatically
             // rejected in any other case
 
             if rejectors_length >= threshold {
                 transaction.tx_status.write(TransactionStatus::REJECTED);
-                self
-                    .emit(
-                        TransactionRejected { transaction_id: tx_id, date_approved: timestamp }
-                    );
+                self.emit(TransactionRejected { transaction_id: tx_id, date_approved: timestamp });
             }
 
             self
                 .emit(
                     TransactionVoted { transaction_id: tx_id, voter: caller, date_voted: timestamp }
                 )
-
         }
 
         fn _update_transaction_status(

--- a/src/account_data.cairo
+++ b/src/account_data.cairo
@@ -19,7 +19,8 @@ pub mod AccountData {
         pub threshold: u64, // the number of members required to approve a transaction for it to be executed
         pub members: Map::<u64, ContractAddress>, // Map(id, member) the members of the account
         pub members_count: u64, // the member length
-        pub has_voted: Map<(u256, ContractAddress), bool> // Map(tx_id, member) -> bool
+        pub has_voted: Map<(u256, ContractAddress), bool>, // Map(tx_id, member) -> bool
+        pub transaction_rejectors: Map<ContractAddress, u256> // Map(member that rejected) -> tx_id
     }
 
     #[starknet::storage_node]
@@ -41,6 +42,7 @@ pub mod AccountData {
         AddedMember: AddedMember,
         ThresholdUpdated: ThresholdUpdated,
         TransactionApproved: TransactionApproved,
+        TransactionRejected: TransactionRejected,
         TransactionVoted: TransactionVoted,
     }
 
@@ -67,6 +69,13 @@ pub mod AccountData {
 
     #[derive(Drop, starknet::Event)]
     pub struct TransactionApproved {
+        #[key]
+        transaction_id: u256,
+        date_approved: u64
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct TransactionRejected {
         #[key]
         transaction_id: u256,
         date_approved: u64
@@ -305,6 +314,44 @@ pub mod AccountData {
                 .emit(
                     TransactionVoted { transaction_id: tx_id, voter: caller, date_voted: timestamp }
                 )
+        }
+
+        fn reject_transaction(
+            ref self: ComponentState<TContractState>, tx_id: u256, caller: ContractAddress
+        ) {
+            // check if caller can vote
+            self.assert_caller_can_vote(tx_id, caller);
+
+            // update has_voted map to prevent double voting
+            self.has_voted.entry((tx_id, caller)).write(true);
+
+            // get the transaction
+            let transaction = self.transactions.entry(tx_id);
+            // add the caller to the list of approvers
+            transaction.rejected.append().write(caller);
+
+            let rejectors_length = transaction.rejected.len();
+            let (threshold, _) = self.get_threshold();
+            let timestamp = get_block_timestamp();
+
+            // check if approval threshold has been reached and update
+            // the transaction status if that is the case. 
+            // According to issue description, transaction is automatically
+            // rejected in any other case
+
+            if rejectors_length >= threshold {
+                transaction.tx_status.write(TransactionStatus::REJECTED);
+                self
+                    .emit(
+                        TransactionRejected { transaction_id: tx_id, date_approved: timestamp }
+                    );
+            }
+
+            self
+                .emit(
+                    TransactionVoted { transaction_id: tx_id, voter: caller, date_voted: timestamp }
+                )
+
         }
 
         fn _update_transaction_status(

--- a/src/tests/mocks/mock_account_data.cairo
+++ b/src/tests/mocks/mock_account_data.cairo
@@ -5,6 +5,7 @@ use starknet::ContractAddress;
 pub trait IMockContract<TContractState> {
     fn create_transaction_pub(ref self: TContractState, tx_type: TransactionType) -> u256;
     fn approve_transaction_pub(ref self: TContractState, tx_id: u256, caller: ContractAddress);
+    fn reject_transaction_pub(ref self: TContractState, tx_id: u256, caller: ContractAddress);
     fn update_transaction_status(ref self: TContractState, tx_id: u256, status: TransactionStatus);
     fn add_member_pub(ref self: TContractState, member: ContractAddress);
     fn assign_proposer_permission_pub(ref self: TContractState, member: ContractAddress);
@@ -59,6 +60,9 @@ pub mod MockContract {
         }
         fn approve_transaction_pub(ref self: ContractState, tx_id: u256, caller: ContractAddress) {
             self.account_data.approve_transaction(tx_id, caller)
+        }
+        fn reject_transaction_pub(ref self: ContractState, tx_id: u256, caller: ContractAddress) {
+            self.account_data.reject_transaction(tx_id, caller)
         }
         fn update_transaction_status(
             ref self: ContractState, tx_id: u256, status: TransactionStatus

--- a/src/tests/test_account_data.cairo
+++ b/src/tests/test_account_data.cairo
@@ -554,7 +554,7 @@ fn test_transaction_status_changes_to_rejected() {
     mock_contract.set_threshold_pub(2);
 
     // Approve Transaction (Should Pass)
-    mock_contract.reject_transaction_pub(tx_id, caller);    
+    mock_contract.reject_transaction_pub(tx_id, caller);
 
     stop_cheat_caller_address(mock_contract.contract_address);
 

--- a/src/tests/test_account_data.cairo
+++ b/src/tests/test_account_data.cairo
@@ -580,21 +580,21 @@ fn test_transaction_status_changes_to_rejected() {
 
     mock_contract.assign_voter_permission_pub(caller_2);
     mock_contract.reject_transaction_pub(tx_id, caller_2);
-    
+
     stop_cheat_caller_address(mock_contract.contract_address);
 
     start_cheat_caller_address(mock_contract.contract_address, caller_3);
 
     mock_contract.assign_voter_permission_pub(caller_3);
     mock_contract.reject_transaction_pub(tx_id, caller_3);
-    
+
     stop_cheat_caller_address(mock_contract.contract_address);
 
     start_cheat_caller_address(mock_contract.contract_address, caller_4);
 
     mock_contract.assign_voter_permission_pub(caller_4);
     mock_contract.reject_transaction_pub(tx_id, caller_4);
-    
+
     stop_cheat_caller_address(mock_contract.contract_address);
 
     let transaction = mock_contract.get_transaction_pub(tx_id);


### PR DESCRIPTION
## Description 📝
This Pull Request implements the ```reject_transaction``` function in the ```account_data``` component. What the function does is give voters the ability to also reject transactions, instead of leaving the condition at deciding not to approve. It also facilitates failing fast in the sense that depending on the threshold, once a number of people interact with the proposal and reject it, the status of the proposal changes to 'rejected', and there is good error handling there.

In the issue description, a canceled status is mentioned for the transactionStatus, and the automatic changing of status to rejected if the number of approvers is less than the threshold. However, that would result in an error as users can only vote in a transaction whose status is initiated, and nothing else. 
Therefore, this PR instead checks if the number of rejecters is greater than or equal to the threshold, and then if yes, it can now change the status, making every other voter afterwards unable to vote.

This PR also covers testing of the newly integrated feature, even for edge cases.

## Related Issues 🔗
Closes #49 

## Changes Made 🚀
- [x] ✨ Feature Implementation 
- [ ] 🐛 Bug Fix 
- [ ] 📚 Documentation Update 
- [ ] 🔨 Refactoring 
- [ ] ❓ Others (Specify) 

## Checklist ✅
- [x] 🛠 I have tested these changes. 
- [ ] 📖 I have updated the documentation (if applicable). 
- [x] 🎨 This PR follows the project's coding style. 
- [x] 🧪 I have added necessary tests (if applicable). 