### PR TITLE
feat: Implement propose_remove_member_transaction

### DIFF
--- a/src/actions/member_remove_transaction.cairo
+++ b/src/actions/member_remove_transaction.cairo
@@ -1,13 +1,13 @@
 #[starknet::component]
 pub mod MemberRemoveTransaction {
-    use spherre::account_data::AccountData::InternalImpl as AccountDataInternalImpl;
-    use spherre::account_data;
-    use spherre::interfaces::iaccount_data::IAccountData;
-    use spherre::interfaces::imember_tx::IMemberRemoveTransaction;
     use openzeppelin_security::PausableComponent::InternalImpl as PausableInternalImpl;
     use openzeppelin_security::pausable::PausableComponent;
+    use spherre::account_data::AccountData::InternalImpl as AccountDataInternalImpl;
+    use spherre::account_data;
     use spherre::components::permission_control;
     use spherre::errors::Errors;
+    use spherre::interfaces::iaccount_data::IAccountData;
+    use spherre::interfaces::imember_tx::IMemberRemoveTransaction;
     use spherre::types::MemberRemoveData;
     use spherre::types::TransactionType;
     use starknet::storage::{

--- a/src/actions/member_remove_transaction.cairo
+++ b/src/actions/member_remove_transaction.cairo
@@ -55,11 +55,10 @@ pub mod MemberRemoveTransaction {
         ) -> u256 {
             let caller = get_caller_address();
 
-            // Validate caller cannot remove themselves
-            assert(caller != member_address, Errors::CANNOT_REMOVE_SELF);
-
             // Get the component states
             let mut account_data_comp = get_dep_component_mut!(ref self, AccountData);
+
+            assert(account_data_comp.is_member(member_address), Errors::ERR_NOT_MEMBER);
 
             // Create transaction through AccountData component
             let transaction_id = account_data_comp
@@ -96,7 +95,10 @@ pub mod MemberRemoveTransaction {
             let account_data_comp = get_dep_component!(self, AccountData);
             let transaction: Transaction = account_data_comp.get_transaction(transaction_id);
 
-            assert(transaction.tx_type == TransactionType::MEMBER_REMOVE, Errors::MEMBER_NOT_FOUND);
+            assert(
+                transaction.tx_type == TransactionType::MEMBER_REMOVE,
+                Errors::INVALID_MEMBER_REMOVE_TRANSACTION
+            );
 
             self.member_removal_transactions.entry(transaction_id).read()
         }

--- a/src/actions/member_remove_transaction.cairo
+++ b/src/actions/member_remove_transaction.cairo
@@ -1,10 +1,171 @@
 #[starknet::component]
 pub mod MemberRemoveTransaction {
+    use spherre::account_data::AccountData::InternalImpl as AccountDataInternalImpl;
+    use spherre::account_data;
+    use spherre::interfaces::iaccount_data::IAccountData;
+    use spherre::interfaces::imember_tx::IMemberRemoveTransaction;
+    use openzeppelin_security::PausableComponent::InternalImpl as PausableInternalImpl;
+    use openzeppelin_security::pausable::PausableComponent;
+    use spherre::components::permission_control;
+    use spherre::errors::Errors;
     use spherre::types::MemberRemoveData;
-    use starknet::storage::{Map, Vec};
+    use spherre::types::TransactionType;
+    use starknet::storage::{
+        StoragePointerReadAccess, StoragePointerWriteAccess, Map, StoragePathEntry, Vec, VecTrait,
+        MutableVecTrait
+    };
+    use starknet::{ContractAddress, get_caller_address, get_block_timestamp};
+
     #[storage]
     pub struct Storage {
-        member_remove_transactions: Map<u256, MemberRemoveData>,
-        member_remove_transaction_ids: Vec<u256>
+        member_removal_transactions: Map<u256, MemberRemoveData>,
+        pending_removal_transaction_ids: Vec<u256>,
+        member_pending_removal: Map<ContractAddress, bool>,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    pub enum Event {
+        MemberRemovalProposed: MemberRemovalProposed,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct MemberRemovalProposed {
+        #[key]
+        pub transaction_id: u256,
+        #[key]
+        pub member_to_remove: ContractAddress,
+        #[key]
+        pub proposer: ContractAddress,
+        pub timestamp: u64,
+    }
+
+
+    #[embeddable_as(MemberRemoveTransactionImpl)]
+    pub impl MemberRemoveTransactionComponentImpl<
+        TContractState,
+        +HasComponent<TContractState>,
+        +Drop<TContractState>,
+        impl AccountData: account_data::AccountData::HasComponent<TContractState>,
+        impl PermissionControl: permission_control::PermissionControl::HasComponent<TContractState>,
+        impl Pausable: PausableComponent::HasComponent<TContractState>,
+    > of IMemberRemoveTransaction<ComponentState<TContractState>> {
+        fn propose_remove_member_transaction(
+            ref self: ComponentState<TContractState>, member_address: ContractAddress
+        ) -> u256 {
+            let caller = get_caller_address();
+
+            // Validate caller cannot remove themselves
+            assert(caller != member_address, Errors::CANNOT_REMOVE_SELF);
+
+            // Get the component states
+            let mut account_data_comp = get_dep_component_mut!(ref self, AccountData);
+
+            // Check if member is already in pending removal process
+            assert(
+                !self.member_pending_removal.entry(member_address).read(),
+                Errors::MEMBER_ALREADY_PENDING_REMOVAL
+            );
+
+            // Create transaction through AccountData component (validates proposer permission)
+            let transaction_id = account_data_comp
+                .create_transaction(TransactionType::MEMBER_REMOVE);
+
+            // Create the member removal transaction
+            let member_removal_transaction = MemberRemoveData {
+                member_address,
+                transaction_id,
+                proposer: caller,
+                created_at: get_block_timestamp(),
+                is_executed: false,
+            };
+
+            // Store the transaction
+            self
+                .member_removal_transactions
+                .entry(transaction_id)
+                .write(member_removal_transaction);
+
+            // Add to pending transactions list
+            self.pending_removal_transaction_ids.append().write(transaction_id);
+
+            // Mark member as pending removal to prevent duplicate proposals
+            self.member_pending_removal.entry(member_address).write(true);
+
+            // Emit event
+            self
+                .emit(
+                    MemberRemovalProposed {
+                        transaction_id,
+                        member_to_remove: member_address,
+                        proposer: caller,
+                        timestamp: get_block_timestamp(),
+                    }
+                );
+
+            transaction_id
+        }
+
+        fn get_member_removal_transaction(
+            self: @ComponentState<TContractState>, transaction_id: u256
+        ) -> MemberRemoveData {
+            let transaction = self.member_removal_transactions.entry(transaction_id).read();
+
+            // Validate transaction exists (check if transaction_id is non-zero)
+            assert(transaction.transaction_id != 0, Errors::TRANSACTION_NOT_FOUND);
+
+            transaction
+        }
+
+        fn member_removal_transaction_list(self: @ComponentState<TContractState>) -> Array<u256> {
+            let mut transaction_ids = ArrayTrait::new();
+            let pending_count = self.pending_removal_transaction_ids.len();
+
+            let mut i = 0;
+            loop {
+                if i >= pending_count {
+                    break;
+                }
+
+                let transaction_id = self.pending_removal_transaction_ids.at(i).read();
+                let transaction = self.member_removal_transactions.entry(transaction_id).read();
+
+                // Only include non-executed transactions
+                if !transaction.is_executed {
+                    transaction_ids.append(transaction_id);
+                }
+
+                i += 1;
+            };
+
+            transaction_ids
+        }
+    }
+
+    #[generate_trait]
+    pub impl InternalImpl<
+        TContractState, +HasComponent<TContractState>, +Drop<TContractState>
+    > of InternalTrait<TContractState> {
+        /// Execute the member removal transaction (called after approval threshold is met)
+        fn execute_member_removal(ref self: ComponentState<TContractState>, transaction_id: u256) {
+            let mut transaction = self.member_removal_transactions.entry(transaction_id).read();
+            assert(!transaction.is_executed, 'Transaction already executed');
+
+            // Mark as executed
+            transaction.is_executed = true;
+            self.member_removal_transactions.entry(transaction_id).write(transaction);
+
+            // Clear pending removal flag
+            self.member_pending_removal.entry(transaction.member_address).write(false);
+            // Remove from pending list would require rebuilding the Vec
+        // This is typically handled by filtering during reads or periodic cleanup
+        }
+
+        /// Check if a member is in pending removal process
+        fn is_member_pending_removal(
+            self: @ComponentState<TContractState>, member_address: ContractAddress
+        ) -> bool {
+            self.member_pending_removal.entry(member_address).read()
+        }
     }
 }

--- a/src/actions/member_remove_transaction.cairo
+++ b/src/actions/member_remove_transaction.cairo
@@ -9,6 +9,7 @@ pub mod MemberRemoveTransaction {
     use spherre::interfaces::iaccount_data::IAccountData;
     use spherre::interfaces::imember_tx::IMemberRemoveTransaction;
     use spherre::types::MemberRemoveData;
+    use spherre::types::{Transaction};
     use spherre::types::TransactionType;
     use starknet::storage::{
         StoragePointerReadAccess, StoragePointerWriteAccess, Map, StoragePathEntry, Vec, VecTrait,
@@ -19,8 +20,7 @@ pub mod MemberRemoveTransaction {
     #[storage]
     pub struct Storage {
         member_removal_transactions: Map<u256, MemberRemoveData>,
-        pending_removal_transaction_ids: Vec<u256>,
-        member_pending_removal: Map<ContractAddress, bool>,
+        member_transaction_ids: Vec<u256>,
     }
 
     #[event]
@@ -41,7 +41,7 @@ pub mod MemberRemoveTransaction {
     }
 
 
-    #[embeddable_as(MemberRemoveTransactionImpl)]
+    #[embeddable_as(MemberRemoveTransaction)]
     pub impl MemberRemoveTransactionComponentImpl<
         TContractState,
         +HasComponent<TContractState>,
@@ -61,23 +61,13 @@ pub mod MemberRemoveTransaction {
             // Get the component states
             let mut account_data_comp = get_dep_component_mut!(ref self, AccountData);
 
-            // Check if member is already in pending removal process
-            assert(
-                !self.member_pending_removal.entry(member_address).read(),
-                Errors::MEMBER_ALREADY_PENDING_REMOVAL
-            );
-
-            // Create transaction through AccountData component (validates proposer permission)
+            // Create transaction through AccountData component
             let transaction_id = account_data_comp
                 .create_transaction(TransactionType::MEMBER_REMOVE);
 
             // Create the member removal transaction
             let member_removal_transaction = MemberRemoveData {
                 member_address,
-                transaction_id,
-                proposer: caller,
-                created_at: get_block_timestamp(),
-                is_executed: false,
             };
 
             // Store the transaction
@@ -85,12 +75,9 @@ pub mod MemberRemoveTransaction {
                 .member_removal_transactions
                 .entry(transaction_id)
                 .write(member_removal_transaction);
+            
+            self.member_transaction_ids.append().write(transaction_id);
 
-            // Add to pending transactions list
-            self.pending_removal_transaction_ids.append().write(transaction_id);
-
-            // Mark member as pending removal to prevent duplicate proposals
-            self.member_pending_removal.entry(member_address).write(true);
 
             // Emit event
             self
@@ -109,63 +96,29 @@ pub mod MemberRemoveTransaction {
         fn get_member_removal_transaction(
             self: @ComponentState<TContractState>, transaction_id: u256
         ) -> MemberRemoveData {
-            let transaction = self.member_removal_transactions.entry(transaction_id).read();
+            let account_data_comp = get_dep_component!(self, AccountData);
+            let transaction: Transaction = account_data_comp.get_transaction(transaction_id);
 
-            // Validate transaction exists (check if transaction_id is non-zero)
-            assert(transaction.transaction_id != 0, Errors::TRANSACTION_NOT_FOUND);
+            assert(
+                transaction.tx_type == TransactionType::MEMBER_REMOVE,
+                Errors::MEMBER_NOT_FOUND
+            );
 
-            transaction
+            self.member_removal_transactions.entry(transaction_id).read()
         }
 
-        fn member_removal_transaction_list(self: @ComponentState<TContractState>) -> Array<u256> {
-            let mut transaction_ids = ArrayTrait::new();
-            let pending_count = self.pending_removal_transaction_ids.len();
+        fn member_removal_transaction_list(self: @ComponentState<TContractState>) -> Array<MemberRemoveData> {
+            let mut array: Array<MemberRemoveData> = array![];
+            let range_stop = self.member_transaction_ids.len();
 
-            let mut i = 0;
-            loop {
-                if i >= pending_count {
-                    break;
-                }
-
-                let transaction_id = self.pending_removal_transaction_ids.at(i).read();
-                let transaction = self.member_removal_transactions.entry(transaction_id).read();
-
-                // Only include non-executed transactions
-                if !transaction.is_executed {
-                    transaction_ids.append(transaction_id);
-                }
-
-                i += 1;
-            };
-
-            transaction_ids
+            for index in 0
+                ..range_stop {
+                    let id = self.member_transaction_ids.at(index).read();
+                    let tx = self.member_removal_transactions.entry(id).read();
+                    array.append(tx);
+                };
+            array
         }
     }
 
-    #[generate_trait]
-    pub impl InternalImpl<
-        TContractState, +HasComponent<TContractState>, +Drop<TContractState>
-    > of InternalTrait<TContractState> {
-        /// Execute the member removal transaction (called after approval threshold is met)
-        fn execute_member_removal(ref self: ComponentState<TContractState>, transaction_id: u256) {
-            let mut transaction = self.member_removal_transactions.entry(transaction_id).read();
-            assert(!transaction.is_executed, 'Transaction already executed');
-
-            // Mark as executed
-            transaction.is_executed = true;
-            self.member_removal_transactions.entry(transaction_id).write(transaction);
-
-            // Clear pending removal flag
-            self.member_pending_removal.entry(transaction.member_address).write(false);
-            // Remove from pending list would require rebuilding the Vec
-        // This is typically handled by filtering during reads or periodic cleanup
-        }
-
-        /// Check if a member is in pending removal process
-        fn is_member_pending_removal(
-            self: @ComponentState<TContractState>, member_address: ContractAddress
-        ) -> bool {
-            self.member_pending_removal.entry(member_address).read()
-        }
-    }
 }

--- a/src/actions/member_remove_transaction.cairo
+++ b/src/actions/member_remove_transaction.cairo
@@ -9,8 +9,8 @@ pub mod MemberRemoveTransaction {
     use spherre::interfaces::iaccount_data::IAccountData;
     use spherre::interfaces::imember_tx::IMemberRemoveTransaction;
     use spherre::types::MemberRemoveData;
-    use spherre::types::{Transaction};
     use spherre::types::TransactionType;
+    use spherre::types::{Transaction};
     use starknet::storage::{
         StoragePointerReadAccess, StoragePointerWriteAccess, Map, StoragePathEntry, Vec, VecTrait,
         MutableVecTrait
@@ -66,18 +66,15 @@ pub mod MemberRemoveTransaction {
                 .create_transaction(TransactionType::MEMBER_REMOVE);
 
             // Create the member removal transaction
-            let member_removal_transaction = MemberRemoveData {
-                member_address,
-            };
+            let member_removal_transaction = MemberRemoveData { member_address, };
 
             // Store the transaction
             self
                 .member_removal_transactions
                 .entry(transaction_id)
                 .write(member_removal_transaction);
-            
-            self.member_transaction_ids.append().write(transaction_id);
 
+            self.member_transaction_ids.append().write(transaction_id);
 
             // Emit event
             self
@@ -99,15 +96,14 @@ pub mod MemberRemoveTransaction {
             let account_data_comp = get_dep_component!(self, AccountData);
             let transaction: Transaction = account_data_comp.get_transaction(transaction_id);
 
-            assert(
-                transaction.tx_type == TransactionType::MEMBER_REMOVE,
-                Errors::MEMBER_NOT_FOUND
-            );
+            assert(transaction.tx_type == TransactionType::MEMBER_REMOVE, Errors::MEMBER_NOT_FOUND);
 
             self.member_removal_transactions.entry(transaction_id).read()
         }
 
-        fn member_removal_transaction_list(self: @ComponentState<TContractState>) -> Array<MemberRemoveData> {
+        fn member_removal_transaction_list(
+            self: @ComponentState<TContractState>
+        ) -> Array<MemberRemoveData> {
             let mut array: Array<MemberRemoveData> = array![];
             let range_stop = self.member_transaction_ids.len();
 
@@ -120,5 +116,4 @@ pub mod MemberRemoveTransaction {
             array
         }
     }
-
 }

--- a/src/errors.cairo
+++ b/src/errors.cairo
@@ -38,8 +38,7 @@ pub mod Errors {
     pub const ERR_INVALID_TOKEN_TRANSACTION: felt252 = 'Invalid Token Transaction';
 
     pub const MEMBER_NOT_FOUND: felt252 = 'Member does not exist';
-    pub const MEMBER_ALREADY_PENDING_REMOVAL: felt252 = 'Member already pending removal';
+    pub const INVALID_MEMBER_REMOVE_TRANSACTION: felt252 = 'Not member remove proposal';
     pub const INSUFFICIENT_MEMBERS_AFTER_REMOVAL: felt252 = 'Would violate minimum threshold';
     pub const TRANSACTION_NOT_FOUND: felt252 = 'Transaction not found';
-    pub const CANNOT_REMOVE_SELF: felt252 = 'Cannot remove yourself';
 }

--- a/src/errors.cairo
+++ b/src/errors.cairo
@@ -36,4 +36,10 @@ pub mod Errors {
     pub const ERR_RECIPIENT_CANNOT_BE_ACCOUNT: felt252 = 'Recipient cannot be account';
     pub const ERR_INVALID_AMOUNT: felt252 = 'Amount is invalid';
     pub const ERR_INVALID_TOKEN_TRANSACTION: felt252 = 'Invalid Token Transaction';
+
+    pub const MEMBER_NOT_FOUND: felt252 = 'Member does not exist';
+    pub const MEMBER_ALREADY_PENDING_REMOVAL: felt252 = 'Member already pending removal';
+    pub const INSUFFICIENT_MEMBERS_AFTER_REMOVAL: felt252 = 'Would violate minimum threshold';
+    pub const TRANSACTION_NOT_FOUND: felt252 = 'Transaction not found';
+    pub const CANNOT_REMOVE_SELF: felt252 = 'Cannot remove yourself';
 }

--- a/src/interfaces/imember_tx.cairo
+++ b/src/interfaces/imember_tx.cairo
@@ -9,5 +9,5 @@ pub trait IMemberRemoveTransaction<TContractState> {
     fn get_member_removal_transaction(
         self: @TContractState, transaction_id: u256
     ) -> MemberRemoveData;
-    fn member_removal_transaction_list(self: @TContractState) -> Array<u256>;
+    fn member_removal_transaction_list(self: @TContractState) -> Array<MemberRemoveData>;
 }

--- a/src/interfaces/imember_tx.cairo
+++ b/src/interfaces/imember_tx.cairo
@@ -1,1 +1,13 @@
+use spherre::types::MemberRemoveData;
+use starknet::ContractAddress;
 
+#[starknet::interface]
+pub trait IMemberRemoveTransaction<TContractState> {
+    fn propose_remove_member_transaction(
+        ref self: TContractState, member_address: ContractAddress
+    ) -> u256;
+    fn get_member_removal_transaction(
+        self: @TContractState, transaction_id: u256
+    ) -> MemberRemoveData;
+    fn member_removal_transaction_list(self: @TContractState) -> Array<u256>;
+}

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -45,8 +45,8 @@ pub mod tests {
     }
     pub mod actions {
         pub mod test_change_threshold_transaction;
+        pub mod test_member_remove_transaction;
         pub mod test_nft_transaction;
         pub mod test_token_transaction;
-        pub mod test_member_remove_transaction;
     }
 }

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -47,5 +47,6 @@ pub mod tests {
         pub mod test_change_threshold_transaction;
         pub mod test_nft_transaction;
         pub mod test_token_transaction;
+        pub mod test_member_remove_transaction;
     }
 }

--- a/src/tests/actions/test_member_remove_transaction.cairo
+++ b/src/tests/actions/test_member_remove_transaction.cairo
@@ -2,13 +2,13 @@ use snforge_std::{
     declare, start_cheat_caller_address, stop_cheat_caller_address, ContractClassTrait,
     DeclareResultTrait
 };
+use spherre::interfaces::ierc20::{IERC20Dispatcher};
 use spherre::tests::mocks::mock_account_data::{
     IMockContractDispatcher, IMockContractDispatcherTrait
 };
-use spherre::interfaces::ierc20::{IERC20Dispatcher};
+use spherre::tests::mocks::mock_token::{IMockTokenDispatcher, IMockTokenDispatcherTrait};
 use spherre::types::{TransactionType, MemberRemoveData};
 use starknet::{ContractAddress, contract_address_const};
-use spherre::tests::mocks::mock_token::{IMockTokenDispatcher, IMockTokenDispatcherTrait};
 
 fn deploy_mock_token() -> IERC20Dispatcher {
     let contract_class = declare("MockToken").unwrap().contract_class();
@@ -41,7 +41,7 @@ fn zero_address() -> ContractAddress {
 }
 
 #[test]
-fn test_propose_member_successful(){
+fn test_propose_member_successful() {
     let mock_contract = deploy_mock_contract();
 
     let caller: ContractAddress = proposer();
@@ -124,9 +124,9 @@ fn test_get_member_removal_transaction_nonexistent_transaction() {
 #[test]
 fn test_member_removal_transaction_list_empty() {
     let mock_contract = deploy_mock_contract();
-    
+
     let result = mock_contract.member_removal_transaction_list_pub();
-    
+
     assert(result.len() == 0, 'List should be empty');
 }
 
@@ -161,7 +161,7 @@ fn test_member_removal_transaction_list_multiple_transactions() {
 
 #[test]
 #[should_panic(expected: ('Cannot remove yourself',))]
-fn test_propose_member_removing_self(){
+fn test_propose_member_removing_self() {
     let mock_contract = deploy_mock_contract();
 
     let caller: ContractAddress = proposer();
@@ -175,5 +175,4 @@ fn test_propose_member_removing_self(){
     // Propose member removal transaction
     let tx_id = mock_contract.propose_remove_member_transaction_pub(member);
     stop_cheat_caller_address(mock_contract.contract_address);
-
 }

--- a/src/tests/actions/test_member_remove_transaction.cairo
+++ b/src/tests/actions/test_member_remove_transaction.cairo
@@ -41,7 +41,7 @@ fn zero_address() -> ContractAddress {
 }
 
 #[test]
-fn test_propose_member_successful() {
+fn test_member_remove_proposal_successful() {
     let mock_contract = deploy_mock_contract();
 
     let caller: ContractAddress = proposer();
@@ -85,7 +85,25 @@ fn test_get_member_removal_transaction_success() {
 
 
 #[test]
-#[should_panic(expected: ('Member does not exist',))]
+#[should_panic(expected: ('Caller is not a member',))]
+fn test_member_remove_proposal_not_member() {
+    let mock_contract = deploy_mock_contract();
+
+    let caller: ContractAddress = proposer();
+    let member: ContractAddress = member_to_remove();
+
+    start_cheat_caller_address(mock_contract.contract_address, caller);
+    mock_contract.add_member_pub(caller);
+    mock_contract.assign_proposer_permission_pub(caller);
+
+    // Propose member removal transaction
+    let tx_id = mock_contract.propose_remove_member_transaction_pub(member);
+    stop_cheat_caller_address(mock_contract.contract_address);
+
+}
+
+#[test]
+#[should_panic(expected: ('Not member remove proposal',))]
 fn test_get_member_removal_transaction_wrong_type() {
     let mock_contract = deploy_mock_contract();
     let caller = proposer();
@@ -159,20 +177,3 @@ fn test_member_removal_transaction_list_multiple_transactions() {
     assert(*result.at(2).member_address == member3, 'Wrong third member');
 }
 
-#[test]
-#[should_panic(expected: ('Cannot remove yourself',))]
-fn test_propose_member_removing_self() {
-    let mock_contract = deploy_mock_contract();
-
-    let caller: ContractAddress = proposer();
-    let member: ContractAddress = member_to_remove();
-
-    start_cheat_caller_address(mock_contract.contract_address, member);
-    mock_contract.add_member_pub(caller);
-    mock_contract.add_member_pub(member);
-    mock_contract.assign_proposer_permission_pub(caller);
-
-    // Propose member removal transaction
-    let tx_id = mock_contract.propose_remove_member_transaction_pub(member);
-    stop_cheat_caller_address(mock_contract.contract_address);
-}

--- a/src/tests/actions/test_member_remove_transaction.cairo
+++ b/src/tests/actions/test_member_remove_transaction.cairo
@@ -1,0 +1,179 @@
+use snforge_std::{
+    declare, start_cheat_caller_address, stop_cheat_caller_address, ContractClassTrait,
+    DeclareResultTrait
+};
+use spherre::tests::mocks::mock_account_data::{
+    IMockContractDispatcher, IMockContractDispatcherTrait
+};
+use spherre::interfaces::ierc20::{IERC20Dispatcher};
+use spherre::types::{TransactionType, MemberRemoveData};
+use starknet::{ContractAddress, contract_address_const};
+use spherre::tests::mocks::mock_token::{IMockTokenDispatcher, IMockTokenDispatcherTrait};
+
+fn deploy_mock_token() -> IERC20Dispatcher {
+    let contract_class = declare("MockToken").unwrap().contract_class();
+    let mut calldata: Array<felt252> = array![];
+    let (contract_address, _) = contract_class.deploy(@calldata).unwrap();
+    IERC20Dispatcher { contract_address }
+}
+
+fn deploy_mock_contract() -> IMockContractDispatcher {
+    let contract_class = declare("MockContract").unwrap().contract_class();
+    let mut calldata = array![];
+    let (contract_address, _) = contract_class.deploy(@calldata).unwrap();
+    IMockContractDispatcher { contract_address }
+}
+
+fn proposer() -> ContractAddress {
+    contract_address_const::<'proposer'>()
+}
+
+fn member_to_remove() -> ContractAddress {
+    contract_address_const::<'member_to_remove'>()
+}
+
+fn other_member() -> ContractAddress {
+    contract_address_const::<'other_member'>()
+}
+
+fn zero_address() -> ContractAddress {
+    contract_address_const::<0>()
+}
+
+#[test]
+fn test_propose_member_successful(){
+    let mock_contract = deploy_mock_contract();
+
+    let caller: ContractAddress = proposer();
+    let member: ContractAddress = member_to_remove();
+
+    start_cheat_caller_address(mock_contract.contract_address, caller);
+    mock_contract.add_member_pub(caller);
+    mock_contract.add_member_pub(member);
+    mock_contract.assign_proposer_permission_pub(caller);
+
+    // Propose member removal transaction
+    let tx_id = mock_contract.propose_remove_member_transaction_pub(member);
+    stop_cheat_caller_address(mock_contract.contract_address);
+
+    let transaction = mock_contract.get_transaction_pub(tx_id);
+    assert(transaction.tx_type == TransactionType::MEMBER_REMOVE, 'Invalid Transaction Type');
+
+    let member_removal_transaction = mock_contract.get_member_removal_transaction_pub(tx_id);
+    assert(member_removal_transaction.member_address == member, 'Member Address Invalid');
+}
+
+#[test]
+fn test_get_member_removal_transaction_success() {
+    let mock_contract = deploy_mock_contract();
+    let caller = proposer();
+    let member = member_to_remove();
+
+    start_cheat_caller_address(mock_contract.contract_address, caller);
+    mock_contract.add_member_pub(caller);
+    mock_contract.add_member_pub(member);
+    mock_contract.assign_proposer_permission_pub(caller);
+
+    // Create a member removal transaction
+    let tx_id = mock_contract.propose_remove_member_transaction_pub(member);
+    stop_cheat_caller_address(mock_contract.contract_address);
+
+    // Test getting the member removal transaction
+    let result = mock_contract.get_member_removal_transaction_pub(tx_id);
+    assert(result.member_address == member, 'Wrong member address');
+}
+
+
+#[test]
+#[should_panic(expected: ('Member does not exist',))]
+fn test_get_member_removal_transaction_wrong_type() {
+    let mock_contract = deploy_mock_contract();
+    let caller = proposer();
+    let token = deploy_mock_token();
+    let amount_to_mint: u256 = 10000000;
+    let amount_to_send: u256 = 100000;
+    let receiver: ContractAddress = other_member();
+
+    let mock_token = IMockTokenDispatcher { contract_address: token.contract_address };
+    mock_token.mint(mock_contract.contract_address, amount_to_mint);
+
+    start_cheat_caller_address(mock_contract.contract_address, caller);
+    mock_contract.add_member_pub(caller);
+    mock_contract.assign_proposer_permission_pub(caller);
+
+    // Create a different type of transaction (not MEMBER_REMOVE)
+    let tx_id = mock_contract
+        .propose_token_transaction_pub(token.contract_address, amount_to_send, receiver);
+    stop_cheat_caller_address(mock_contract.contract_address);
+
+    // This should panic with MEMBER_NOT_FOUND error
+    mock_contract.get_member_removal_transaction_pub(tx_id);
+}
+
+
+#[test]
+#[should_panic(expected: ('Transaction is out of range',))]
+fn test_get_member_removal_transaction_nonexistent_transaction() {
+    let mock_contract = deploy_mock_contract();
+    let nonexistent_id = 999_u256;
+
+    // This should panic as the transaction doesn't exist
+    mock_contract.get_member_removal_transaction_pub(nonexistent_id);
+}
+
+#[test]
+fn test_member_removal_transaction_list_empty() {
+    let mock_contract = deploy_mock_contract();
+    
+    let result = mock_contract.member_removal_transaction_list_pub();
+    
+    assert(result.len() == 0, 'List should be empty');
+}
+
+#[test]
+fn test_member_removal_transaction_list_multiple_transactions() {
+    let mock_contract = deploy_mock_contract();
+    let caller = proposer();
+    let member1 = member_to_remove();
+    let member2 = other_member();
+    let member3 = contract_address_const::<'third_member'>();
+
+    start_cheat_caller_address(mock_contract.contract_address, caller);
+    mock_contract.add_member_pub(caller);
+    mock_contract.add_member_pub(member1);
+    mock_contract.add_member_pub(member2);
+    mock_contract.add_member_pub(member3);
+    mock_contract.assign_proposer_permission_pub(caller);
+
+    // Create multiple member removal transactions
+    mock_contract.propose_remove_member_transaction_pub(member1);
+    mock_contract.propose_remove_member_transaction_pub(member2);
+    mock_contract.propose_remove_member_transaction_pub(member3);
+    stop_cheat_caller_address(mock_contract.contract_address);
+
+    let result = mock_contract.member_removal_transaction_list_pub();
+
+    assert(result.len() == 3, 'Should have three transactions');
+    assert(*result.at(0).member_address == member1, 'Wrong first member');
+    assert(*result.at(1).member_address == member2, 'Wrong second member');
+    assert(*result.at(2).member_address == member3, 'Wrong third member');
+}
+
+#[test]
+#[should_panic(expected: ('Cannot remove yourself',))]
+fn test_propose_member_removing_self(){
+    let mock_contract = deploy_mock_contract();
+
+    let caller: ContractAddress = proposer();
+    let member: ContractAddress = member_to_remove();
+
+    start_cheat_caller_address(mock_contract.contract_address, member);
+    mock_contract.add_member_pub(caller);
+    mock_contract.add_member_pub(member);
+    mock_contract.assign_proposer_permission_pub(caller);
+
+    // Propose member removal transaction
+    let tx_id = mock_contract.propose_remove_member_transaction_pub(member);
+    stop_cheat_caller_address(mock_contract.contract_address);
+
+}

--- a/src/tests/actions/test_member_remove_transaction.cairo
+++ b/src/tests/actions/test_member_remove_transaction.cairo
@@ -99,7 +99,6 @@ fn test_member_remove_proposal_not_member() {
     // Propose member removal transaction
     let tx_id = mock_contract.propose_remove_member_transaction_pub(member);
     stop_cheat_caller_address(mock_contract.contract_address);
-
 }
 
 #[test]

--- a/src/tests/mocks/mock_account_data.cairo
+++ b/src/tests/mocks/mock_account_data.cairo
@@ -39,7 +39,9 @@ pub trait IMockContract<TContractState> {
     fn get_all_threshold_change_transactions_pub(
         self: @TContractState
     ) -> Array<ThresholdChangeData>;
-    fn propose_remove_member_transaction_pub(ref self: TContractState, member_address: ContractAddress) -> u256;
+    fn propose_remove_member_transaction_pub(
+        ref self: TContractState, member_address: ContractAddress
+    ) -> u256;
     fn get_member_removal_transaction_pub(self: @TContractState, id: u256) -> MemberRemoveData;
     fn member_removal_transaction_list_pub(self: @TContractState) -> Array<MemberRemoveData>;
 }
@@ -51,9 +53,9 @@ pub mod MockContract {
     use openzeppelin_security::pausable::PausableComponent;
     use spherre::account_data::AccountData;
     use spherre::actions::change_threshold_transaction::ChangeThresholdTransaction;
+    use spherre::actions::member_remove_transaction::MemberRemoveTransaction;
     use spherre::actions::nft_transaction::NFTTransaction;
     use spherre::actions::token_transaction::TokenTransaction;
-    use spherre::actions::member_remove_transaction::MemberRemoveTransaction;
     use spherre::components::permission_control::{PermissionControl};
     use spherre::interfaces::itoken_tx::ITokenTransaction;
     use spherre::types::{
@@ -71,9 +73,7 @@ pub mod MockContract {
     component!(
         path: ChangeThresholdTransaction, storage: change_threshold, event: ChangeThresholdEvent
     );
-    component!(
-        path: MemberRemoveTransaction, storage: member_remove, event: MemberRemoveEvent
-    );
+    component!(path: MemberRemoveTransaction, storage: member_remove, event: MemberRemoveEvent);
 
     #[abi(embed_v0)]
     pub impl AccountDataImpl = AccountData::AccountData<ContractState>;
@@ -249,15 +249,11 @@ pub mod MockContract {
             self.member_remove.propose_remove_member_transaction(member_address)
         }
 
-        fn get_member_removal_transaction_pub(
-            self: @ContractState, id: u256
-        ) -> MemberRemoveData {
+        fn get_member_removal_transaction_pub(self: @ContractState, id: u256) -> MemberRemoveData {
             self.member_remove.get_member_removal_transaction(id)
         }
 
-        fn member_removal_transaction_list_pub(
-            self: @ContractState
-        ) -> Array<MemberRemoveData> {
+        fn member_removal_transaction_list_pub(self: @ContractState) -> Array<MemberRemoveData> {
             self.member_remove.member_removal_transaction_list()
         }
     }

--- a/src/tests/mocks/mock_account_data.cairo
+++ b/src/tests/mocks/mock_account_data.cairo
@@ -1,6 +1,6 @@
 use spherre::types::{
     TransactionType, Transaction, NFTTransactionData, TransactionStatus, TokenTransactionData,
-    ThresholdChangeData,
+    ThresholdChangeData, MemberRemoveData,
 };
 use starknet::ContractAddress;
 
@@ -39,6 +39,9 @@ pub trait IMockContract<TContractState> {
     fn get_all_threshold_change_transactions_pub(
         self: @TContractState
     ) -> Array<ThresholdChangeData>;
+    fn propose_remove_member_transaction_pub(ref self: TContractState, member_address: ContractAddress) -> u256;
+    fn get_member_removal_transaction_pub(self: @TContractState, id: u256) -> MemberRemoveData;
+    fn member_removal_transaction_list_pub(self: @TContractState) -> Array<MemberRemoveData>;
 }
 
 
@@ -50,11 +53,12 @@ pub mod MockContract {
     use spherre::actions::change_threshold_transaction::ChangeThresholdTransaction;
     use spherre::actions::nft_transaction::NFTTransaction;
     use spherre::actions::token_transaction::TokenTransaction;
+    use spherre::actions::member_remove_transaction::MemberRemoveTransaction;
     use spherre::components::permission_control::{PermissionControl};
     use spherre::interfaces::itoken_tx::ITokenTransaction;
     use spherre::types::{
         Transaction, TransactionType, TransactionStatus, TokenTransactionData, NFTTransactionData,
-        ThresholdChangeData,
+        ThresholdChangeData, MemberRemoveData,
     };
     use starknet::ContractAddress;
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess,};
@@ -66,6 +70,9 @@ pub mod MockContract {
     component!(path: NFTTransaction, storage: nft_transaction, event: NFTTransactionEvent);
     component!(
         path: ChangeThresholdTransaction, storage: change_threshold, event: ChangeThresholdEvent
+    );
+    component!(
+        path: MemberRemoveTransaction, storage: member_remove, event: MemberRemoveEvent
     );
 
     #[abi(embed_v0)]
@@ -92,6 +99,10 @@ pub mod MockContract {
     pub impl ChangeThresholdTransactionImpl =
         ChangeThresholdTransaction::ChangeThresholdTransaction<ContractState>;
 
+    #[abi(embed_v0)]
+    pub impl MemberRemovalTransactionImpl =
+        MemberRemoveTransaction::MemberRemoveTransaction<ContractState>;
+
 
     #[storage]
     pub struct Storage {
@@ -107,6 +118,8 @@ pub mod MockContract {
         pub nft_transaction: NFTTransaction::Storage,
         #[substorage(v0)]
         pub change_threshold: ChangeThresholdTransaction::Storage,
+        #[substorage(v0)]
+        pub member_remove: MemberRemoveTransaction::Storage,
     }
 
     #[event]
@@ -124,6 +137,8 @@ pub mod MockContract {
         NFTTransactionEvent: NFTTransaction::Event,
         #[flat]
         ChangeThresholdEvent: ChangeThresholdTransaction::Event,
+        #[flat]
+        MemberRemoveEvent: MemberRemoveTransaction::Event,
     }
 
     #[abi(embed_v0)]
@@ -226,6 +241,24 @@ pub mod MockContract {
                 .change_threshold
                 .get_all_threshold_change_transactions();
             threshold_change_txs
+        }
+
+        fn propose_remove_member_transaction_pub(
+            ref self: ContractState, member_address: ContractAddress
+        ) -> u256 {
+            self.member_remove.propose_remove_member_transaction(member_address)
+        }
+
+        fn get_member_removal_transaction_pub(
+            self: @ContractState, id: u256
+        ) -> MemberRemoveData {
+            self.member_remove.get_member_removal_transaction(id)
+        }
+
+        fn member_removal_transaction_list_pub(
+            self: @ContractState
+        ) -> Array<MemberRemoveData> {
+            self.member_remove.member_removal_transaction_list()
         }
     }
 

--- a/src/types.cairo
+++ b/src/types.cairo
@@ -110,10 +110,6 @@ pub struct EditPermissionData {
 #[derive(Copy, Drop, Serde, starknet::Store)]
 pub struct MemberRemoveData {
     pub member_address: ContractAddress,
-    pub transaction_id: u256,
-    pub proposer: ContractAddress,
-    pub created_at: u64,
-    pub is_executed: bool,
 }
 
 #[derive(Drop, Serde)]

--- a/src/types.cairo
+++ b/src/types.cairo
@@ -107,9 +107,13 @@ pub struct EditPermissionData {
     pub permissions: Array<PermissionEnum>
 }
 
-#[derive(Drop, Serde, starknet::Store)]
+#[derive(Copy, Drop, Serde, starknet::Store)]
 pub struct MemberRemoveData {
-    pub member: ContractAddress
+    pub member_address: ContractAddress,
+    pub transaction_id: u256,
+    pub proposer: ContractAddress,
+    pub created_at: u64,
+    pub is_executed: bool,
 }
 
 #[derive(Drop, Serde)]


### PR DESCRIPTION
## Description 📝
This PR implements the functionality to propose a member removal transaction in our multisignature account system. Authorized members can now initiate a proposal to remove another member from the multisig account.

## Related Issues 🔗
closes #71 

## Changes Made 🚀
- [x] ✨ Feature Implementation 
- [ ] 🐛 Bug Fix 
- [ ] 📚 Documentation Update 
- [ ] 🔨 Refactoring 
- [ ] ❓ Others (Specify) 

## Screenshots/Screen-record (if applicable) 🖼
<!-- If the change includes UI updates, add screenshots or link to screen recording here. -->

## Checklist ✅
- [x] 🛠 I have tested these changes. 
- [ ] 📖 I have updated the documentation (if applicable). 
- [x] 🎨 This PR follows the project's coding style. 
- [x] 🧪 I have added necessary tests (if applicable). 

## Additional Notes 🗒
<!-- Any other relevant details or concerns. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to propose, retrieve, and list member removal transactions, including event notifications when a member removal is proposed.
- **Bug Fixes**
  - Added new error messages for scenarios like non-existent members, invalid removal proposals, insufficient members after removal, and missing transactions.
- **Tests**
  - Added comprehensive test coverage for member removal transactions, including success cases and error conditions.
- **Documentation**
  - Updated interface definitions to reflect new member removal transaction capabilities.
- **Style**
  - Refined naming conventions for improved clarity in member removal data structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->