### PR TITLE
feat: integrate OpenZeppelin UpgradeableComponent to make Spherre c

### DIFF
--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -36,11 +36,13 @@ pub mod tests {
     pub mod test_account_upgrade;
     pub mod test_permission_control;
     pub mod test_spherre;
+    pub mod test_spherre_upgrade;
     pub mod utils;
     pub mod mocks {
         pub mod mock_accountV2;
         pub mod mock_account_data;
         pub mod mock_nft;
+        pub mod mock_spherreV2;
         pub mod mock_token;
     }
     pub mod actions {

--- a/src/tests/mocks/mock_spherreV2.cairo
+++ b/src/tests/mocks/mock_spherreV2.cairo
@@ -1,5 +1,35 @@
+use starknet::{ClassHash, ContractAddress};
+
+#[starknet::interface]
+pub trait ISpherreV2<TContractState> {
+    // Existing functions from V1
+    fn grant_superadmin_role(ref self: TContractState, account: ContractAddress);
+    fn grant_staff_role(ref self: TContractState, account: ContractAddress);
+    fn revoke_superadmin_role(ref self: TContractState, account: ContractAddress);
+    fn revoke_staff_role(ref self: TContractState, account: ContractAddress);
+    fn has_staff_role(self: @TContractState, account: ContractAddress) -> bool;
+    fn has_superadmin_role(self: @TContractState, account: ContractAddress) -> bool;
+    fn pause(ref self: TContractState);
+    fn unpause(ref self: TContractState);
+    fn deploy_account(
+        ref self: TContractState,
+        owner: ContractAddress,
+        name: ByteArray,
+        description: ByteArray,
+        members: Array<ContractAddress>,
+        threshold: u64,
+    ) -> ContractAddress;
+    fn is_deployed_account(self: @TContractState, account: ContractAddress) -> bool;
+    // New functions for class hash management
+    fn update_account_class_hash(ref self: TContractState, new_class_hash: ClassHash);
+    fn get_account_class_hash(self: @TContractState) -> ClassHash;
+
+    // New V2 functions
+    fn get_version(self: @TContractState) -> u8;
+}
+
 #[starknet::contract]
-pub mod Spherre {
+pub mod SpherreV2 {
     use core::hash::{HashStateExTrait, HashStateTrait};
     use core::num::traits::Zero;
     use core::poseidon::PoseidonTrait;
@@ -11,19 +41,18 @@ pub mod Spherre {
     use openzeppelin::security::reentrancyguard::ReentrancyGuardComponent;
     use openzeppelin::upgrades::UpgradeableComponent;
     use openzeppelin::upgrades::interface::IUpgradeable;
-    use spherre::account::SpherreAccount;
     use spherre::errors::Errors;
-    use spherre::interfaces::ispherre::ISpherre;
     use spherre::types::SpherreAdminRoles;
     use starknet::storage::{
         Map, MutableVecTrait, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess,
-        Vec, VecTrait,
+        Vec,
     };
     use starknet::syscalls::deploy_syscall;
     use starknet::{
         ClassHash, ContractAddress, get_block_number, get_block_timestamp, get_caller_address,
         get_contract_address,
     };
+    use super::ISpherreV2;
 
     // Interface IDs
 
@@ -100,12 +129,12 @@ pub mod Spherre {
     impl AccessControlMixinImpl = AccessControlComponent::AccessControlMixinImpl<ContractState>;
     impl AccessControlInternalImpl = AccessControlComponent::InternalImpl<ContractState>;
 
+    // Upgradeable component implementation
+    pub impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
+
     // Implement SRC5 mixin
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
     impl SRC5InternalImpl = SRC5Component::InternalImpl<ContractState>;
-
-    // Upgradeable component implementation
-    pub impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
 
     #[derive(Drop, starknet::Event)]
     struct AccountDeployed {
@@ -132,7 +161,7 @@ pub mod Spherre {
 
     // Implement the ISpherre interface
     #[abi(embed_v0)]
-    pub impl SpherreImpl of ISpherre<ContractState> {
+    pub impl SpherreImpl of ISpherreV2<ContractState> {
         fn grant_superadmin_role(ref self: ContractState, account: ContractAddress) {
             self.ownable.assert_only_owner();
             self.access_control._grant_role(SpherreAdminRoles::SUPERADMIN, account);
@@ -248,6 +277,11 @@ pub mod Spherre {
 
         fn get_account_class_hash(self: @ContractState) -> ClassHash {
             self.account_class_hash.read()
+        }
+
+        // New V2 functions
+        fn get_version(self: @ContractState) -> u8 {
+            2 // Return the version number of the contract
         }
     }
 

--- a/src/tests/test_spherre_upgrade.cairo
+++ b/src/tests/test_spherre_upgrade.cairo
@@ -1,0 +1,150 @@
+use crate::interfaces::iaccount::{IAccountDispatcher, IAccountDispatcherTrait};
+use crate::interfaces::iaccount_data::{IAccountDataDispatcher, IAccountDataDispatcherTrait};
+use crate::interfaces::ispherre::{ISpherreDispatcher, ISpherreDispatcherTrait};
+use crate::spherre::Spherre;
+use openzeppelin::upgrades::interface::{IUpgradeableDispatcher, IUpgradeableDispatcherTrait};
+use openzeppelin::upgrades::upgradeable::UpgradeableComponent::{Event as UpgradeEvent, Upgraded};
+use snforge_std::{
+    ContractClassTrait, DeclareResultTrait, EventSpyAssertionsTrait, EventSpyTrait, declare,
+    get_class_hash, spy_events, start_cheat_caller_address, stop_cheat_caller_address,
+};
+use spherre::tests::mocks::mock_spherreV2::{ISpherreV2Dispatcher, ISpherreV2DispatcherTrait};
+use starknet::{ClassHash, ContractAddress, contract_address_const};
+
+
+// --- Helper Functions ---
+
+// Declare Contract Class and return the Class Hash
+fn declare_contract(name: ByteArray) -> ClassHash {
+    let declare_result = declare(name);
+    let declared_contract = declare_result.unwrap().contract_class();
+    *declared_contract.class_hash
+}
+
+// --- Setup ---
+
+fn setup_test(owner: ContractAddress) -> (ISpherreDispatcher, ClassHash) {
+    // Setup
+    let declare_result_v1 = declare("Spherre").unwrap();
+    let v1_contract_class = declare_result_v1.contract_class();
+
+    let v2_class_hash = declare_contract("SpherreV2");
+
+    let mut constructor_calldata = array![];
+    owner.serialize(ref constructor_calldata);
+    let (v1_contract_address, _) = v1_contract_class.deploy(@constructor_calldata).unwrap();
+
+    let v1 = ISpherreDispatcher { contract_address: v1_contract_address };
+    (v1, v2_class_hash)
+}
+
+// Deploy spherre account to get classhash
+fn get_spherre_account_class_hash() -> ClassHash {
+    let contract_class = declare("SpherreAccount").unwrap().contract_class();
+    contract_class.class_hash.clone()
+}
+
+fn OWNER() -> ContractAddress {
+    contract_address_const::<'Owner'>()
+}
+fn MEMBER_ONE() -> ContractAddress {
+    contract_address_const::<'Member_one'>()
+}
+fn MEMBER_TWO() -> ContractAddress {
+    contract_address_const::<'Member_two'>()
+}
+
+#[test]
+fn test_upgrade_to_v2_success() {
+    // Setup
+    let owner: ContractAddress = OWNER();
+    let (v1, v2_class_hash) = setup_test(owner);
+
+    // Grant superadmin role to deployer
+    let deployer: ContractAddress = contract_address_const::<'deployer'>();
+    start_cheat_caller_address(v1.contract_address, owner);
+    v1.grant_superadmin_role(deployer);
+    stop_cheat_caller_address(v1.contract_address);
+
+    // Spy on events, perform upgrade as deployer
+    let mut spy = spy_events();
+    start_cheat_caller_address(v1.contract_address, deployer);
+    IUpgradeableDispatcher { contract_address: v1.contract_address }.upgrade(v2_class_hash);
+    stop_cheat_caller_address(v1.contract_address);
+
+    // Verify upgrade event
+    let expected_upgrade_event = Spherre::Event::UpgradeableEvent(
+        UpgradeEvent::Upgraded(Upgraded { class_hash: v2_class_hash }),
+    );
+    let expected_events = array![(v1.contract_address, expected_upgrade_event)];
+    spy.assert_emitted(@expected_events);
+
+    // Verify the upgrade was successful by checking the class hash
+    let current_class_hash = get_class_hash(v1.contract_address);
+    assert!(current_class_hash == v2_class_hash, "Contract not upgraded to v2");
+
+    // Get V2 dispatcher
+    let v2 = ISpherreV2Dispatcher { contract_address: v1.contract_address };
+
+    // Test new V2 functionality
+    assert_eq!(v2.get_version(), 2); // Default value
+}
+
+#[test]
+#[should_panic(expected: ('Caller is not a superadmin',))]
+fn test_upgrade_non_superadmin_fails() {
+    // Setup
+    let owner: ContractAddress = OWNER();
+    let (v1, v2_class_hash) = setup_test(owner);
+
+    // Attempt upgrade as a non-superadmin
+    let non_superadmin: ContractAddress = contract_address_const::<'non_superadmin'>();
+    start_cheat_caller_address(v1.contract_address, non_superadmin);
+    IUpgradeableDispatcher { contract_address: v1.contract_address }.upgrade(v2_class_hash);
+    stop_cheat_caller_address(v1.contract_address);
+}
+
+#[test]
+fn test_upgrade_preserves_state() {
+    // Setup
+    let owner: ContractAddress = OWNER();
+    let (v1, v2_class_hash) = setup_test(owner);
+    let spherre_dispatcher = ISpherreDispatcher { contract_address: v1.contract_address };
+
+    let account_classhash: ClassHash = get_spherre_account_class_hash();
+    start_cheat_caller_address(v1.contract_address, owner);
+    ISpherreDispatcher { contract_address: v1.contract_address }
+        .update_account_class_hash(account_classhash);
+    stop_cheat_caller_address(v1.contract_address);
+
+    // Deploy a SpherreAccount in v1
+    let name: ByteArray = "Test Spherre Account";
+    let description: ByteArray = "Test Spherre Account Description";
+    let members: Array<ContractAddress> = array![owner, MEMBER_ONE(), MEMBER_TWO()];
+    let threshold: u64 = 2;
+    let account_address = spherre_dispatcher
+        .deploy_account(owner, name, description, members, threshold);
+
+    // Capture initial state of the deployed account
+    let account_data = IAccountDataDispatcher { contract_address: account_address };
+    let account_info = IAccountDispatcher { contract_address: account_address };
+
+    let is_member_initial = account_data.is_member(owner);
+    let (threshold_initial, members_count_initial) = account_data.get_threshold();
+    let name_initial = account_info.get_name();
+
+    // Perform upgrade of the Spherre implementation
+    start_cheat_caller_address(v1.contract_address, owner);
+    IUpgradeableDispatcher { contract_address: v1.contract_address }.upgrade(v2_class_hash);
+    stop_cheat_caller_address(v1.contract_address);
+
+    // After upgrade verify if state is preserved
+    let is_member_after = account_data.is_member(owner);
+    let (threshold_after, members_count_after) = account_data.get_threshold();
+    let name_after = account_info.get_name();
+
+    assert_eq!(is_member_after, is_member_initial, "Membership was not preserved");
+    assert_eq!(threshold_after, threshold_initial, "Threshold was not preserved");
+    assert_eq!(members_count_after, members_count_initial, "Member count was not preserved");
+    assert_eq!(name_after, name_initial, "Account name was not preserved");
+}


### PR DESCRIPTION
## Description 📝
This PR adds upgradeability to the spherre.cairo contract by integrating OpenZeppelin’s UpgradeableComponent. SUPERADMINs can now call the `upgrade` method to replace the implementation without losing state. I’ve added full test coverage to verify the upgrade process, access control, event emission, and state preservation.

## Related Issues 🔗
Implement #78 

## Changes Made 🚀
- [X] ✨ Feature Implementation 

## Checklist ✅
- [X] 🛠 I have tested these changes. 
- [X] 🎨 This PR follows the project's coding style. 
- [X] 🧪 I have added necessary tests (if applicable). 

## Additional Notes 🗒
Staying available if any changes or improvements are needed. Thanks 