### PR TITLE
Feat: added Openzeppelin ERC721 Component into Spherre contract with tests

### DIFF
--- a/src/interfaces/ispherre.cairo
+++ b/src/interfaces/ispherre.cairo
@@ -128,25 +128,26 @@ pub trait ISpherre<TContractState> {
     /// # Panics
     /// This function raises an error if the caller does not have the superadmin role.
     fn upgrade(ref self: TContractState, new_class_hash: ClassHash);
-    /// Returns `IERC721_RECEIVER_ID` to confirm the receipt of an ERC721 token through safe transfers.
+    /// Returns `IERC721_RECEIVER_ID` to confirm the receipt of an ERC721 token through safe
+    /// transfers.
     /// This function is called when an ERC721 token is received by the Spherre contract.
-    /// 
+    ///
     /// # Parameters
     /// * `operator` - The contract address of the operator who initiated the transfer.
     /// * `from` - The contract address of the sender of the token.
     /// * `token_id` - The ID of the ERC721 token being transferred.
-    /// * `data` - Additional data sent with the token transfer, as a byte array.
-    /// 
+    /// * `data` - Additional data sent with the token transfer, as an Array of felts.
+    ///
     /// # Returns
     /// * `felt252` - A value indicating the openzeppelin receiver (IERC721) ID.
-    /// 
+    ///
     /// # Panics
-    /// 
-    fn on_erc721_received(
-        self: @TContractState,
-        operator: ContractAddress,
-        from: ContractAddress,
-        token_id: u256,
-        data: Span<felt252>,
-    ) -> felt252;
+    ///
+    // fn on_erc721_received(
+    //     self: @TContractState,
+    //     operator: ContractAddress,
+    //     from: ContractAddress,
+    //     token_id: u256,
+    //     data: Span<felt252>,
+    // ) -> felt252;
 }

--- a/src/interfaces/ispherre.cairo
+++ b/src/interfaces/ispherre.cairo
@@ -128,4 +128,25 @@ pub trait ISpherre<TContractState> {
     /// # Panics
     /// This function raises an error if the caller does not have the superadmin role.
     fn upgrade(ref self: TContractState, new_class_hash: ClassHash);
+    /// Returns `IERC721_RECEIVER_ID` to confirm the receipt of an ERC721 token through safe transfers.
+    /// This function is called when an ERC721 token is received by the Spherre contract.
+    /// 
+    /// # Parameters
+    /// * `operator` - The contract address of the operator who initiated the transfer.
+    /// * `from` - The contract address of the sender of the token.
+    /// * `token_id` - The ID of the ERC721 token being transferred.
+    /// * `data` - Additional data sent with the token transfer, as a byte array.
+    /// 
+    /// # Returns
+    /// * `felt252` - A value indicating the openzeppelin receiver (IERC721) ID.
+    /// 
+    /// # Panics
+    /// 
+    fn on_erc721_received(
+        self: @TContractState,
+        operator: ContractAddress,
+        from: ContractAddress,
+        token_id: u256,
+        data: Span<felt252>,
+    ) -> felt252;
 }

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -37,6 +37,7 @@ pub mod tests {
     pub mod test_account_upgrade;
     pub mod test_permission_control;
     pub mod test_spherre;
+    pub mod test_spherre_receiver;
     pub mod test_spherre_upgrade;
     pub mod utils;
     pub mod mocks {

--- a/src/spherre.cairo
+++ b/src/spherre.cairo
@@ -9,6 +9,7 @@ pub mod Spherre {
     use openzeppelin::introspection::src5::SRC5Component;
     use openzeppelin::security::pausable::PausableComponent;
     use openzeppelin::security::reentrancyguard::ReentrancyGuardComponent;
+    use openzeppelin::token::erc721::ERC721ReceiverComponent;
     use openzeppelin::upgrades::UpgradeableComponent;
     use openzeppelin::upgrades::interface::IUpgradeable;
     use spherre::account::SpherreAccount;
@@ -48,6 +49,8 @@ pub mod Spherre {
         src5: SRC5Component::Storage,
         #[substorage(v0)]
         upgradeable: UpgradeableComponent::Storage,
+        #[substorage(v0)]
+        erc721_receiver: ERC721ReceiverComponent::Storage,
     }
 
     #[event]
@@ -67,6 +70,8 @@ pub mod Spherre {
         SRC5Event: SRC5Component::Event,
         #[flat]
         UpgradeableEvent: UpgradeableComponent::Event,
+        #[flat]
+        ERC721ReceiverEvent: ERC721ReceiverComponent::Event,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -84,6 +89,7 @@ pub mod Spherre {
     component!(path: AccessControlComponent, storage: access_control, event: AccessControlEvent);
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
     component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
+    component!(path: ERC721ReceiverComponent, storage: erc721_receiver, event: ERC721ReceiverEvent);
 
     // Implement Ownable mixin
     impl OwnableMixinImpl = OwnableComponent::OwnableMixinImpl<ContractState>;
@@ -107,6 +113,10 @@ pub mod Spherre {
     // Upgradeable component implementation
     pub impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
 
+    // Implement ERC721Receiver mixin
+    impl ERC721ReceiverImpl = ERC721ReceiverComponent::ERC721ReceiverImpl<ContractState>;
+    impl ERC721ReceiverInternalImpl = ERC721ReceiverComponent::InternalImpl<ContractState>;
+
     #[derive(Drop, starknet::Event)]
     struct AccountDeployed {
         account_address: ContractAddress,
@@ -128,6 +138,9 @@ pub mod Spherre {
         self.access_control.initializer();
         self.access_control._grant_role(DEFAULT_ADMIN_ROLE, owner);
         self.access_control._grant_role(SpherreAdminRoles::SUPERADMIN, owner);
+
+        // Initialize ERC721Receiver
+        self.erc721_receiver.initializer();
     }
 
     // Implement the ISpherre interface

--- a/src/spherre.cairo
+++ b/src/spherre.cairo
@@ -270,6 +270,16 @@ pub mod Spherre {
             // Replace the class hash, hence upgrading the contract
             self.upgradeable.upgrade(new_class_hash);
         }
+
+        fn on_erc721_received(
+            self: @ContractState,
+            operator: ContractAddress,
+            from: ContractAddress,
+            token_id: u256,
+            data: Span<felt252>,
+        ) -> felt252 {
+            self.erc721_receiver.on_erc721_received(operator, from, token_id, data)
+        }
     }
 
     #[generate_trait]

--- a/src/spherre.cairo
+++ b/src/spherre.cairo
@@ -46,11 +46,11 @@ pub mod Spherre {
         #[substorage(v0)]
         access_control: AccessControlComponent::Storage,
         #[substorage(v0)]
-        src5: SRC5Component::Storage,
+        pub src5: SRC5Component::Storage,
         #[substorage(v0)]
         upgradeable: UpgradeableComponent::Storage,
         #[substorage(v0)]
-        erc721_receiver: ERC721ReceiverComponent::Storage,
+        pub erc721_receiver: ERC721ReceiverComponent::Storage,
     }
 
     #[event]
@@ -114,7 +114,8 @@ pub mod Spherre {
     pub impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
 
     // Implement ERC721Receiver mixin
-    impl ERC721ReceiverImpl = ERC721ReceiverComponent::ERC721ReceiverImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC721ReceiverMixinImpl = ERC721ReceiverComponent::ERC721ReceiverMixinImpl<ContractState>;
     impl ERC721ReceiverInternalImpl = ERC721ReceiverComponent::InternalImpl<ContractState>;
 
     #[derive(Drop, starknet::Event)]
@@ -269,16 +270,6 @@ pub mod Spherre {
 
             // Replace the class hash, hence upgrading the contract
             self.upgradeable.upgrade(new_class_hash);
-        }
-
-        fn on_erc721_received(
-            self: @ContractState,
-            operator: ContractAddress,
-            from: ContractAddress,
-            token_id: u256,
-            data: Span<felt252>,
-        ) -> felt252 {
-            self.erc721_receiver.on_erc721_received(operator, from, token_id, data)
         }
     }
 

--- a/src/spherre.cairo
+++ b/src/spherre.cairo
@@ -115,7 +115,8 @@ pub mod Spherre {
 
     // Implement ERC721Receiver mixin
     #[abi(embed_v0)]
-    impl ERC721ReceiverMixinImpl = ERC721ReceiverComponent::ERC721ReceiverMixinImpl<ContractState>;
+    impl ERC721ReceiverMixinImpl =
+        ERC721ReceiverComponent::ERC721ReceiverMixinImpl<ContractState>;
     impl ERC721ReceiverInternalImpl = ERC721ReceiverComponent::InternalImpl<ContractState>;
 
     #[derive(Drop, starknet::Event)]

--- a/src/tests/test_spherre_receiver.cairo
+++ b/src/tests/test_spherre_receiver.cairo
@@ -2,21 +2,28 @@
 mod tests {
     // use super::*;
     // use openzeppelin::token::erc721::ERC721Receiver;
+    use crate::interfaces::ispherre::{ISpherreDispatcher, ISpherreDispatcherTrait};
     use crate::spherre::{Spherre, Spherre::SpherreImpl};
-    use openzeppelin::token::erc721::interface::{
-        IERC721_RECEIVER_ID, IERC721Receiver,
-    };
     use openzeppelin::introspection::interface::ISRC5_ID;
     use openzeppelin::introspection::src5::SRC5Component::SRC5Impl;
+    use openzeppelin::token::erc721::interface::{IERC721_RECEIVER_ID, IERC721Receiver,};
+    use snforge_std::{
+        declare, start_cheat_caller_address, get_class_hash, stop_cheat_caller_address,
+        ContractClassTrait, DeclareResultTrait, spy_events, EventSpyTrait, EventSpyAssertionsTrait
+    };
+    use spherre::interfaces::ierc721::{IERC721Dispatcher, IERC721DispatcherTrait};
+    use spherre::tests::mocks::mock_nft::{IMockNFTDispatcher, IMockNFTDispatcherTrait};
     use starknet::{ContractAddress, contract_address_const};
 
     // Constants for testing
     fn OWNER() -> ContractAddress {
         contract_address_const::<'Owner'>()
     }
+
     fn OPERATOR() -> ContractAddress {
         contract_address_const::<'Operator'>()
     }
+
     const TOKEN_ID: u256 = 1;
 
     // Helper function to set up test contract
@@ -24,7 +31,7 @@ mod tests {
         let owner = OWNER();
 
         let mut contract_state = Spherre::contract_state_for_testing();
-        
+
         Spherre::constructor(ref contract_state, owner);
 
         contract_state
@@ -35,8 +42,27 @@ mod tests {
         Spherre::contract_state_for_testing()
     }
 
+    fn deploy_mock_erc721() -> IERC721Dispatcher {
+        let contract_class = declare("MockNFT").unwrap().contract_class();
+        let mut calldata: Array<felt252> = array![];
+        let (contract_address, _) = contract_class.deploy(@calldata).unwrap();
+        IERC721Dispatcher { contract_address }
+    }
+
+    // Helper function to deploy Spherre contract (for integration tests as a recipient)
+    fn deploy_spherre() -> ISpherreDispatcher {
+        let contract = declare("Spherre").unwrap().contract_class();
+        let owner = OWNER();
+        let mut constructor_calldata = array![];
+        owner.serialize(ref constructor_calldata);
+        let (contract_address, _) = contract.deploy(@constructor_calldata).unwrap();
+        ISpherreDispatcher { contract_address }
+    }
+
+    // --- Unit tests for Spherre receiver logic ---
+
     #[test]
-    fn initial_state() {
+    fn test_initial_state() {
         let contract_state = setup_test_contract();
 
         // Verify interface support
@@ -47,30 +73,75 @@ mod tests {
         assert!(supports_isrc5, "SRC5 interface not supported");
     }
 
-
     #[test]
     fn test_on_erc721_received() {
         let contract_state = setup_test_contract();
 
         // Test with empty data
         let empty_data = array![].span();
-        let result: felt252 = contract_state.erc721_receiver.on_erc721_received(OPERATOR(), OWNER(), TOKEN_ID, empty_data);
-        assert_eq!(
-            result,
-            IERC721_RECEIVER_ID,
-            "Should return ERC721Receiver interface ID"
-        );
+        let result: felt252 = contract_state
+            .erc721_receiver
+            .on_erc721_received(OPERATOR(), OWNER(), TOKEN_ID, empty_data);
+        assert_eq!(result, IERC721_RECEIVER_ID, "Should return ERC721Receiver interface ID");
 
         // Test with some data
         let with_data = array![123.into(), 456.into()].span();
-        let result_with_data: felt252 = contract_state.erc721_receiver.on_erc721_received(OPERATOR(), OWNER(), TOKEN_ID,
-        with_data);
+        let result_with_data: felt252 = contract_state
+            .erc721_receiver
+            .on_erc721_received(OPERATOR(), OWNER(), TOKEN_ID, with_data);
         assert_eq!(
-            result_with_data,
-            IERC721_RECEIVER_ID,
-            "Should also return ERC721Receiver interface ID"
+            result_with_data, IERC721_RECEIVER_ID, "Should also return ERC721Receiver interface ID"
         );
     }
 
+     // --- Integration tests for ERC721 transfers ---
+     #[test]
+     fn test_approved_safe_transfer_to_spherre() {
+        let erc721_contract = deploy_mock_erc721();
+        let spherre_contract = deploy_spherre();
+        let minter = OWNER();
+        let operator = OPERATOR();
 
+        // Mint a token to the owner
+        start_cheat_caller_address(erc721_contract.contract_address, minter);
+        IMockNFTDispatcher{ contract_address: erc721_contract.contract_address }.mint(minter, TOKEN_ID);
+        stop_cheat_caller_address(erc721_contract.contract_address);
+
+        // Verify owner is the minter initially
+        let initial_owner = erc721_contract.owner_of(TOKEN_ID);
+        assert_eq!(initial_owner, minter, "Initial owner should be minter");
+
+        // Approve Operator to transfer the token
+        start_cheat_caller_address(erc721_contract.contract_address, minter);
+        erc721_contract.approve(operator, TOKEN_ID);
+        stop_cheat_caller_address(erc721_contract.contract_address);
+
+        // Setup event spy before the transfer call
+        let mut spy = spy_events();
+
+        // Safe transfer from to Spherre
+        // Caller must be owner or approved
+        let data = array![123.into()].span(); // Empty data for the transfer
+        start_cheat_caller_address(erc721_contract.contract_address, operator);
+        erc721_contract.safe_transfer_from(minter, spherre_contract.contract_address, TOKEN_ID, data);
+        stop_cheat_caller_address(erc721_contract.contract_address);
+
+        // Verify that Spherre contract now owns the token
+        let new_owner = erc721_contract.owner_of(TOKEN_ID);
+        assert_eq!(new_owner, spherre_contract.contract_address, "Spherre contract should own the token");
+
+        // Verify the Transfer event was emitted by the ERC721 contract
+        // Event structure: Transfer { from: ContractAddress, to: ContractAddress, token_id: u256 }
+        // let expected_transfer_event = MockERC721::Event::ERC721Event(
+        //     MockERC721::ERC721Component::Event::Transfer(
+        //         MockERC721::ERC721Component::Transfer {
+        //             from: minter,
+        //             to: spherre_address,
+        //             token_id: TOKEN_ID
+        //         }
+        //     )
+        // );
+        // let expected_events = array![(erc721_address, expected_transfer_event)];
+        // spy.assert_emitted(@expected_events);
+     }
 }

--- a/src/tests/test_spherre_receiver.cairo
+++ b/src/tests/test_spherre_receiver.cairo
@@ -1,0 +1,76 @@
+#[cfg(test)]
+mod tests {
+    // use super::*;
+    // use openzeppelin::token::erc721::ERC721Receiver;
+    use crate::spherre::{Spherre, Spherre::SpherreImpl};
+    use openzeppelin::token::erc721::interface::{
+        IERC721_RECEIVER_ID, IERC721Receiver,
+    };
+    use openzeppelin::introspection::interface::ISRC5_ID;
+    use openzeppelin::introspection::src5::SRC5Component::SRC5Impl;
+    use starknet::{ContractAddress, contract_address_const};
+
+    // Constants for testing
+    fn OWNER() -> ContractAddress {
+        contract_address_const::<'Owner'>()
+    }
+    fn OPERATOR() -> ContractAddress {
+        contract_address_const::<'Operator'>()
+    }
+    const TOKEN_ID: u256 = 1;
+
+    // Helper function to set up test contract
+    fn setup_test_contract() -> Spherre::ContractState {
+        let owner = OWNER();
+
+        let mut contract_state = Spherre::contract_state_for_testing();
+        
+        Spherre::constructor(ref contract_state, owner);
+
+        contract_state
+    }
+
+    // setting up the contract state
+    fn CONTRACT_STATE() -> Spherre::ContractState {
+        Spherre::contract_state_for_testing()
+    }
+
+    #[test]
+    fn initial_state() {
+        let contract_state = setup_test_contract();
+
+        // Verify interface support
+        let supports_ierc721_receiver = contract_state.src5.supports_interface(IERC721_RECEIVER_ID);
+        assert!(supports_ierc721_receiver, "ERC721Receiver interface not supported");
+
+        let supports_isrc5 = contract_state.src5.supports_interface(ISRC5_ID);
+        assert!(supports_isrc5, "SRC5 interface not supported");
+    }
+
+
+    #[test]
+    fn test_on_erc721_received() {
+        let contract_state = setup_test_contract();
+
+        // Test with empty data
+        let empty_data = array![].span();
+        let result: felt252 = contract_state.erc721_receiver.on_erc721_received(OPERATOR(), OWNER(), TOKEN_ID, empty_data);
+        assert_eq!(
+            result,
+            IERC721_RECEIVER_ID,
+            "Should return ERC721Receiver interface ID"
+        );
+
+        // Test with some data
+        let with_data = array![123.into(), 456.into()].span();
+        let result_with_data: felt252 = contract_state.erc721_receiver.on_erc721_received(OPERATOR(), OWNER(), TOKEN_ID,
+        with_data);
+        assert_eq!(
+            result_with_data,
+            IERC721_RECEIVER_ID,
+            "Should also return ERC721Receiver interface ID"
+        );
+    }
+
+
+}


### PR DESCRIPTION
## Description 📝
<!-- Provide a brief description of the changes made, fixes or feature added in this pull request. -->
I've successfully added the ERC721Receiver component to the Spherre contract. 

The contract can now:
- Safely receive ERC721 tokens through the standard `safe_transfer_from`/`safeTransferFrom` functions
- Handle incoming NFT transfers properly
- Emit events for tracking token receipts
- Maintain compatibility with the ERC721 standard

## Related Issues 🔗
<!-- Link to related issues (if applicable), e.g., Fixes #123. -->
- Closes: #100

## Changes Made 🚀
- [x] ✨ Feature Implementation 
- [ ] 🐛 Bug Fix 
- [ ] 📚 Documentation Update 
- [ ] 🔨 Refactoring 
- [ ] ❓ Others (Specify) 

## Screenshots/Screen-record (if applicable) 🖼
<!-- If the change includes UI updates, add screenshots or link to screen recording here. -->

## Checklist ✅
- [x] 🛠 I have tested these changes. 
- [ ] 📖 I have updated the documentation (if applicable). 
- [x] 🎨 This PR follows the project's coding style. 
- [x] 🧪 I have added necessary tests (if applicable). 

## Additional Notes 🗒
<!-- Any other relevant details or concerns. -->