### PR TITLE
fix: collect fees should transfer from caller

### DIFF
--- a/src/account_data.cairo
+++ b/src/account_data.cairo
@@ -842,7 +842,7 @@ pub mod AccountData {
                 Errors::ERR_INSUFFICIENT_ALLOWANCE
             );
             // Transfer Fee
-            erc20_dispatcher.transfer_from(account_address, deployer, fee);
+            erc20_dispatcher.transfer_from(caller, deployer, fee);
             // Update the collection statistics
             deployer_dispatcher.update_fee_collection_statistics(fee_type, fee);
         }

--- a/src/account_data.cairo
+++ b/src/account_data.cairo
@@ -831,7 +831,6 @@ pub mod AccountData {
             }
 
             // Collect the fees from the account
-            // TODO: change fee collection from account to caller
             // Check if the caller balance is enough to pay fee
             let erc20_dispatcher = IERC20Dispatcher { contract_address: fee_token };
             let caller = get_caller_address();

--- a/src/tests/test_fee_collection.cairo
+++ b/src/tests/test_fee_collection.cairo
@@ -1,4 +1,4 @@
-// use crate::interfaces::iaccount_data::{IAccountDataDispatcher, IAccountDataDispatcherTrait};
+use crate::interfaces::iaccount_data::{IAccountDataDispatcher, IAccountDataDispatcherTrait};
 use crate::interfaces::ispherre::{ISpherreDispatcher, ISpherreDispatcherTrait};
 use crate::spherre::Spherre::{SpherreImpl};
 use crate::spherre::Spherre;
@@ -6,11 +6,10 @@ use snforge_std::{
     start_cheat_caller_address, stop_cheat_caller_address, declare, ContractClassTrait,
     DeclareResultTrait,
 };
-use spherre::interfaces::ierc20::{IERC20Dispatcher};
-// use spherre::interfaces::itoken_tx::{ITokenTransactionDispatcher,
-// ITokenTransactionDispatcherTrait};
-// use spherre::tests::mocks::mock_token::{IMockTokenDispatcher, IMockTokenDispatcherTrait};
-// use spherre::types::{FeesType};
+use spherre::interfaces::ierc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+use spherre::interfaces::itoken_tx::{ITokenTransactionDispatcher, ITokenTransactionDispatcherTrait};
+use spherre::tests::mocks::mock_token::{IMockTokenDispatcher, IMockTokenDispatcherTrait};
+use spherre::types::{FeesType};
 use starknet::{ContractAddress, contract_address_const, ClassHash,};
 
 
@@ -66,81 +65,281 @@ fn cheat_set_account_class_hash(
     ISpherreDispatcher { contract_address }.update_account_class_hash(new_hash);
     stop_cheat_caller_address(contract_address);
 }
-// TODO: figure out why insufficient balance assertion is called and
-// why the test is failing.
 
-// #[test]
-// fn test_fee_collection_successfull() {
-//     let spherre_contract = deploy_contract(OWNER());
-//     let spherre_dispatcher = ISpherreDispatcher { contract_address: spherre_contract };
-//     let owner = OWNER();
-//     let token = deploy_mock_token();
-//     let fee: u256 = 10000;
-//     let amount_to_propose: u256 = 1000000;
-//     let receiver: ContractAddress = contract_address_const::<'recipient'>();
-//     // Set classhash
-//     let classhash: ClassHash = get_spherre_account_class_hash();
-//     cheat_set_account_class_hash(spherre_contract, classhash, owner);
-//     // Update the fees token and fee
-//     start_cheat_caller_address(spherre_contract, owner);
-//     spherre_dispatcher.update_fee_token(token.contract_address);
-//     spherre_dispatcher.update_fee(FeesType::PROPOSAL_FEE, fee);
-//     stop_cheat_caller_address(spherre_contract);
-//     // Check if fee token is set
-//     assert(
-//         spherre_dispatcher.get_fee(FeesType::PROPOSAL_FEE, 1.try_into().unwrap()) == fee,
-//         'Invalid fee'
-//     );
-//     assert(
-//         spherre_dispatcher.get_fee_token() == token.contract_address,
-//         'Invalid fee token'
-//     );
-//     // Call the deploy account function
-//     let name: ByteArray = "Test Spherre Account";
-//     let description: ByteArray = "Test Spherre Account Description";
-//     let members: Array<ContractAddress> = array![owner, MEMBER_ONE(), MEMBER_TWO()];
-//     let threshold: u64 = 2;
-//     let account_address = spherre_dispatcher
-//         .deploy_account(owner, name, description, members, threshold);
-//     // Test newly deployed spherre contract
-//     assert(spherre_dispatcher.is_deployed_account(account_address), 'Account not deployed');
-//     let spherre_account_data_dispatcher = IAccountDataDispatcher {
-//         contract_address: account_address
-//     };
-//     // Check that the account is deployed properly
-//     assert(spherre_account_data_dispatcher.is_member(OWNER()), 'Not a member');
+#[test]
+fn test_fee_collection_successfull() {
+    let spherre_contract = deploy_contract(OWNER());
+    let spherre_dispatcher = ISpherreDispatcher { contract_address: spherre_contract };
+    let owner = OWNER();
+    let fee_token = deploy_mock_token();
+    let fee: u256 = 10000;
+    let amount_fee_to_mint: u256 = 20000;
+    let amount_to_propose: u256 = 1000000;
+    let receiver: ContractAddress = contract_address_const::<'recipient'>();
+    // Set classhash
+    let classhash: ClassHash = get_spherre_account_class_hash();
+    cheat_set_account_class_hash(spherre_contract, classhash, owner);
+    // Update the fees token and fee
+    start_cheat_caller_address(spherre_contract, owner);
+    spherre_dispatcher.update_fee_token(fee_token.contract_address);
+    spherre_dispatcher.update_fee(FeesType::PROPOSAL_FEE, fee);
+    stop_cheat_caller_address(spherre_contract);
+    // Check if fee token is set
+    assert(
+        spherre_dispatcher.get_fee(FeesType::PROPOSAL_FEE, 1.try_into().unwrap()) == fee,
+        'Invalid fee'
+    );
+    assert(spherre_dispatcher.get_fee_token() == fee_token.contract_address, 'Invalid fee token');
+    // Call the deploy account function
+    let name: ByteArray = "Test Spherre Account";
+    let description: ByteArray = "Test Spherre Account Description";
+    let members: Array<ContractAddress> = array![owner, MEMBER_ONE(), MEMBER_TWO()];
+    let threshold: u64 = 2;
+    let account_address = spherre_dispatcher
+        .deploy_account(owner, name, description, members, threshold);
+    // Test newly deployed spherre contract
+    assert(spherre_dispatcher.is_deployed_account(account_address), 'Account not deployed');
+    let spherre_account_data_dispatcher = IAccountDataDispatcher {
+        contract_address: account_address
+    };
+    // Check that the account is deployed properly
+    assert(spherre_account_data_dispatcher.is_member(OWNER()), 'Not a member');
 
-//     // Propose a transaction like a token transfer transaction
-//     // But first, mint the token
-//     let token = deploy_mock_token();
-//     let mint_dispatcher = IMockTokenDispatcher{contract_address: token.contract_address};
-//     let amount_to_mint: u256 = 100000000000000;
-//     start_cheat_caller_address(account_address, owner);
-//     mint_dispatcher.mint(owner, amount_to_mint);
-//     // Mint for account address
-//     mint_dispatcher.mint(account_address, amount_to_mint);
-//     assert(
-//         token.balance_of(owner) == amount_to_mint,
-//         'Invalid mint balance'
-//     );
+    // Mint and set allowance for fee token
+    start_cheat_caller_address(fee_token.contract_address, owner);
+    fee_token.approve(account_address, fee);
+    IMockTokenDispatcher { contract_address: fee_token.contract_address }
+        .mint(owner, amount_fee_to_mint);
+    stop_cheat_caller_address(fee_token.contract_address);
 
-//     // Propose the token transaction
-//     let token_transaction_dispatcher = ITokenTransactionDispatcher{contract_address:
-//     account_address};
+    // Propose a transaction like a token transfer transaction
+    // But first, mint the token
+    let token = deploy_mock_token();
+    let mint_dispatcher = IMockTokenDispatcher { contract_address: token.contract_address };
+    let amount_to_mint: u256 = 100000000000000;
+    start_cheat_caller_address(account_address, owner);
+    mint_dispatcher.mint(owner, amount_to_mint);
+    // Mint for account address
+    mint_dispatcher.mint(account_address, amount_to_mint);
+    assert(token.balance_of(owner) == amount_to_mint, 'Invalid mint balance');
 
-//     token_transaction_dispatcher.propose_token_transaction(
-//         token.contract_address,
-//         amount_to_propose,
-//         receiver
-//     );
-//     stop_cheat_caller_address(account_address);
-//     // Start the checks
-//     // Check whether the balance minted has changed
-//     let expected_balance = amount_to_mint - fee;
-//     assert(
-//         token.balance_of(owner) == expected_balance,
-//         'Invalid balance'
-//     );
-// }
+    // Propose the token transaction
+    let token_transaction_dispatcher = ITokenTransactionDispatcher {
+        contract_address: account_address
+    };
 
+    token_transaction_dispatcher
+        .propose_token_transaction(token.contract_address, amount_to_propose, receiver);
+    stop_cheat_caller_address(account_address);
+    // Start the checks
+    // Check whether the balance minted has changed
+    let expected_balance = amount_fee_to_mint - fee;
+    assert(fee_token.balance_of(owner) == expected_balance, 'Invalid balance for fee token');
+}
 
+#[test]
+fn test_fee_collection_successfull_just_enough_fee() {
+    let spherre_contract = deploy_contract(OWNER());
+    let spherre_dispatcher = ISpherreDispatcher { contract_address: spherre_contract };
+    let owner = OWNER();
+    let fee_token = deploy_mock_token();
+    let fee: u256 = 10000;
+    let amount_fee_to_mint: u256 = fee;
+    let amount_to_propose: u256 = 1000000;
+    let receiver: ContractAddress = contract_address_const::<'recipient'>();
+    // Set classhash
+    let classhash: ClassHash = get_spherre_account_class_hash();
+    cheat_set_account_class_hash(spherre_contract, classhash, owner);
+    // Update the fees token and fee
+    start_cheat_caller_address(spherre_contract, owner);
+    spherre_dispatcher.update_fee_token(fee_token.contract_address);
+    spherre_dispatcher.update_fee(FeesType::PROPOSAL_FEE, fee);
+    stop_cheat_caller_address(spherre_contract);
+    // Check if fee token is set
+    assert(
+        spherre_dispatcher.get_fee(FeesType::PROPOSAL_FEE, 1.try_into().unwrap()) == fee,
+        'Invalid fee'
+    );
+    assert(spherre_dispatcher.get_fee_token() == fee_token.contract_address, 'Invalid fee token');
+    // Call the deploy account function
+    let name: ByteArray = "Test Spherre Account";
+    let description: ByteArray = "Test Spherre Account Description";
+    let members: Array<ContractAddress> = array![owner, MEMBER_ONE(), MEMBER_TWO()];
+    let threshold: u64 = 2;
+    let account_address = spherre_dispatcher
+        .deploy_account(owner, name, description, members, threshold);
+    // Test newly deployed spherre contract
+    assert(spherre_dispatcher.is_deployed_account(account_address), 'Account not deployed');
+    let spherre_account_data_dispatcher = IAccountDataDispatcher {
+        contract_address: account_address
+    };
+    // Check that the account is deployed properly
+    assert(spherre_account_data_dispatcher.is_member(OWNER()), 'Not a member');
+
+    // Mint and set allowance for fee token
+    start_cheat_caller_address(fee_token.contract_address, owner);
+    fee_token.approve(account_address, fee);
+    IMockTokenDispatcher { contract_address: fee_token.contract_address }
+        .mint(owner, amount_fee_to_mint);
+    stop_cheat_caller_address(fee_token.contract_address);
+
+    // Propose a transaction like a token transfer transaction
+    // But first, mint the token
+    let token = deploy_mock_token();
+    let mint_dispatcher = IMockTokenDispatcher { contract_address: token.contract_address };
+    let amount_to_mint: u256 = 100000000000000;
+    start_cheat_caller_address(account_address, owner);
+    mint_dispatcher.mint(owner, amount_to_mint);
+    // Mint for account address
+    mint_dispatcher.mint(account_address, amount_to_mint);
+    assert(token.balance_of(owner) == amount_to_mint, 'Invalid mint balance');
+
+    // Propose the token transaction
+    let token_transaction_dispatcher = ITokenTransactionDispatcher {
+        contract_address: account_address
+    };
+
+    token_transaction_dispatcher
+        .propose_token_transaction(token.contract_address, amount_to_propose, receiver);
+    stop_cheat_caller_address(account_address);
+    // Start the checks
+    // Check whether the balance minted has changed
+    let expected_balance: u256 = 0;
+    assert(fee_token.balance_of(owner) == expected_balance, 'Invalid balance for fee token');
+}
+
+#[test]
+#[should_panic(expected: 'Insufficient fee balance')]
+fn test_fee_collection_insufficient_fee_balance() {
+    let spherre_contract = deploy_contract(OWNER());
+    let spherre_dispatcher = ISpherreDispatcher { contract_address: spherre_contract };
+    let owner = OWNER();
+    let fee_token = deploy_mock_token();
+    let fee: u256 = 10000;
+    let amount_fee_to_mint: u256 = fee - 100; // Less than fee
+    let amount_to_propose: u256 = 1000000;
+    let receiver: ContractAddress = contract_address_const::<'recipient'>();
+    // Set classhash
+    let classhash: ClassHash = get_spherre_account_class_hash();
+    cheat_set_account_class_hash(spherre_contract, classhash, owner);
+    // Update the fees token and fee
+    start_cheat_caller_address(spherre_contract, owner);
+    spherre_dispatcher.update_fee_token(fee_token.contract_address);
+    spherre_dispatcher.update_fee(FeesType::PROPOSAL_FEE, fee);
+    stop_cheat_caller_address(spherre_contract);
+    // Check if fee token is set
+    assert(
+        spherre_dispatcher.get_fee(FeesType::PROPOSAL_FEE, 1.try_into().unwrap()) == fee,
+        'Invalid fee'
+    );
+    assert(spherre_dispatcher.get_fee_token() == fee_token.contract_address, 'Invalid fee token');
+    // Call the deploy account function
+    let name: ByteArray = "Test Spherre Account";
+    let description: ByteArray = "Test Spherre Account Description";
+    let members: Array<ContractAddress> = array![owner, MEMBER_ONE(), MEMBER_TWO()];
+    let threshold: u64 = 2;
+    let account_address = spherre_dispatcher
+        .deploy_account(owner, name, description, members, threshold);
+    // Test newly deployed spherre contract
+    assert(spherre_dispatcher.is_deployed_account(account_address), 'Account not deployed');
+    let spherre_account_data_dispatcher = IAccountDataDispatcher {
+        contract_address: account_address
+    };
+    // Check that the account is deployed properly
+    assert(spherre_account_data_dispatcher.is_member(OWNER()), 'Not a member');
+
+    // Mint and set allowance for fee token
+    start_cheat_caller_address(fee_token.contract_address, owner);
+    fee_token.approve(account_address, fee);
+    IMockTokenDispatcher { contract_address: fee_token.contract_address }
+        .mint(owner, amount_fee_to_mint);
+    stop_cheat_caller_address(fee_token.contract_address);
+
+    // Propose a transaction like a token transfer transaction
+    // But first, mint the token
+    let token = deploy_mock_token();
+    let mint_dispatcher = IMockTokenDispatcher { contract_address: token.contract_address };
+    let amount_to_mint: u256 = 100000000000000;
+    start_cheat_caller_address(account_address, owner);
+    mint_dispatcher.mint(owner, amount_to_mint);
+    // Mint for account address
+    mint_dispatcher.mint(account_address, amount_to_mint);
+    assert(token.balance_of(owner) == amount_to_mint, 'Invalid mint balance');
+
+    // Propose the token transaction
+    let token_transaction_dispatcher = ITokenTransactionDispatcher {
+        contract_address: account_address
+    };
+
+    token_transaction_dispatcher
+        .propose_token_transaction(token.contract_address, amount_to_propose, receiver);
+    stop_cheat_caller_address(account_address);
+}
+
+#[test]
+#[should_panic(expected: 'Insufficient fee allowance')]
+fn test_fee_collection_insufficient_fee_allowance() {
+    let spherre_contract = deploy_contract(OWNER());
+    let spherre_dispatcher = ISpherreDispatcher { contract_address: spherre_contract };
+    let owner = OWNER();
+    let fee_token = deploy_mock_token();
+    let fee: u256 = 10000;
+    let amount_fee_to_mint: u256 = fee + 100;
+    let amount_to_propose: u256 = 1000000;
+    let receiver: ContractAddress = contract_address_const::<'recipient'>();
+    // Set classhash
+    let classhash: ClassHash = get_spherre_account_class_hash();
+    cheat_set_account_class_hash(spherre_contract, classhash, owner);
+    // Update the fees token and fee
+    start_cheat_caller_address(spherre_contract, owner);
+    spherre_dispatcher.update_fee_token(fee_token.contract_address);
+    spherre_dispatcher.update_fee(FeesType::PROPOSAL_FEE, fee);
+    stop_cheat_caller_address(spherre_contract);
+    // Check if fee token is set
+    assert(
+        spherre_dispatcher.get_fee(FeesType::PROPOSAL_FEE, 1.try_into().unwrap()) == fee,
+        'Invalid fee'
+    );
+    assert(spherre_dispatcher.get_fee_token() == fee_token.contract_address, 'Invalid fee token');
+    // Call the deploy account function
+    let name: ByteArray = "Test Spherre Account";
+    let description: ByteArray = "Test Spherre Account Description";
+    let members: Array<ContractAddress> = array![owner, MEMBER_ONE(), MEMBER_TWO()];
+    let threshold: u64 = 2;
+    let account_address = spherre_dispatcher
+        .deploy_account(owner, name, description, members, threshold);
+    // Test newly deployed spherre contract
+    assert(spherre_dispatcher.is_deployed_account(account_address), 'Account not deployed');
+    let spherre_account_data_dispatcher = IAccountDataDispatcher {
+        contract_address: account_address
+    };
+    // Check that the account is deployed properly
+    assert(spherre_account_data_dispatcher.is_member(OWNER()), 'Not a member');
+
+    // Mint and set allowance for fee token
+    start_cheat_caller_address(fee_token.contract_address, owner);
+    fee_token.approve(account_address, fee - 100); // Less than fee
+    IMockTokenDispatcher { contract_address: fee_token.contract_address }
+        .mint(owner, amount_fee_to_mint);
+    stop_cheat_caller_address(fee_token.contract_address);
+
+    // Propose a transaction like a token transfer transaction
+    // But first, mint the token
+    let token = deploy_mock_token();
+    let mint_dispatcher = IMockTokenDispatcher { contract_address: token.contract_address };
+    let amount_to_mint: u256 = 100000000000000;
+    start_cheat_caller_address(account_address, owner);
+    mint_dispatcher.mint(owner, amount_to_mint);
+    // Mint for account address
+    mint_dispatcher.mint(account_address, amount_to_mint);
+    assert(token.balance_of(owner) == amount_to_mint, 'Invalid mint balance');
+
+    // Propose the token transaction
+    let token_transaction_dispatcher = ITokenTransactionDispatcher {
+        contract_address: account_address
+    };
+
+    token_transaction_dispatcher
+        .propose_token_transaction(token.contract_address, amount_to_propose, receiver);
+    stop_cheat_caller_address(account_address);
+}


### PR DESCRIPTION
## Description 📝
<!-- Provide a brief description of the changes made, fixes or feature added in this pull request. -->
- fee token should be transfered from caller and not from the account.
- Add tests for insufficient fee token balance and fee token allowance.

## Related Issues 🔗
<!-- Link to related issues (if applicable), e.g., Fixes #123. -->
Closes #132 

## Changes Made 🚀
- [ ] ✨ Feature Implementation 
- [x] 🐛 Bug Fix 
- [ ] 📚 Documentation Update 
- [ ] 🔨 Refactoring 
- [ ] ❓ Others (Specify) 

## Screenshots/Screen-record (if applicable) 🖼
<!-- If the change includes UI updates, add screenshots or link to screen recording here. -->

## Checklist ✅
- [x] 🛠 I have tested these changes. 
- [ ] 📖 I have updated the documentation (if applicable). 
- [x] 🎨 This PR follows the project's coding style. 
- [x] 🧪 I have added necessary tests (if applicable). 

## Additional Notes 🗒
<!-- Any other relevant details or concerns. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated fee collection to transfer fees from the caller’s balance instead of the account’s balance.

* **Tests**
  * Expanded and reorganized fee collection tests covering successful transfers, exact fee amounts, insufficient balance, and insufficient allowance scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->