### PR TITLE
build: cleanup Scarb.toml

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -2,24 +2,6 @@
 version = 1
 
 [[package]]
-name = "alexandria_data_structures"
-version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?tag=v0.2.0#bcc4fa417abbc8b067ae6f2d382b127006b5077c"
-
-[[package]]
-name = "alexandria_sorting"
-version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?tag=v0.2.0#bcc4fa417abbc8b067ae6f2d382b127006b5077c"
-dependencies = [
- "alexandria_data_structures",
-]
-
-[[package]]
-name = "alexandria_storage"
-version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?tag=v0.2.0#bcc4fa417abbc8b067ae6f2d382b127006b5077c"
-
-[[package]]
 name = "openzeppelin"
 version = "0.18.0"
 source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.18.0#2f37306b490e63c0afa9e33ad192ba428141b487"
@@ -141,9 +123,6 @@ dependencies = [
 name = "spherre"
 version = "0.1.0"
 dependencies = [
- "alexandria_data_structures",
- "alexandria_sorting",
- "alexandria_storage",
  "openzeppelin",
  "snforge_std",
 ]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -9,12 +9,11 @@ edition = "2024_07"
 
 [dependencies]
 starknet = "2.8.5"
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.35.1" }
 assert_macros = "2.8.5"
 openzeppelin = { git = "https://github.com/openzeppelin/cairo-contracts", tag = "v0.18.0" }
-alexandria_storage = { git = "https://github.com/keep-starknet-strange/alexandria.git", tag = "v0.2.0" }
-alexandria_sorting = { git = "https://github.com/keep-starknet-strange/alexandria.git", tag = "v0.2.0" }
-alexandria_data_structures = { git = "https://github.com/keep-starknet-strange/alexandria.git", tag = "v0.2.0" }
+
+[dev-dependencies]
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.35.1" }
 
 [tool.fmt]
 sort-module-level-items = true


### PR DESCRIPTION
## Description 📝
<!-- Provide a brief description of the changes made, fixes or feature added in this pull request. -->
While working on #136 , I have found that Scarb.toml have the following issues:
- `alexandria` is imported but not used in this project
- `snforge_std` is in `[dependencies]` and not `[dev-dependencies]`

This PR fix theses issues.

## Related Issues 🔗
<!-- Link to related issues (if applicable), e.g., Fixes #123. -->

## Changes Made 🚀
- [ ] ✨ Feature Implementation 
- [ ] 🐛 Bug Fix 
- [ ] 📚 Documentation Update 
- [ ] 🔨 Refactoring 
- [x] ❓ Others (Specify) 

## Screenshots/Screen-record (if applicable) 🖼
<!-- If the change includes UI updates, add screenshots or link to screen recording here. -->

## Checklist ✅
- [x] 🛠 I have tested these changes. 
- [ ] 📖 I have updated the documentation (if applicable). 
- [ ] 🎨 This PR follows the project's coding style. 
- [ ] 🧪 I have added necessary tests (if applicable). 

## Additional Notes 🗒
<!-- Any other relevant details or concerns. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management to improve project organization and remove unused packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->